### PR TITLE
DM: fix mouse enum and some joystick fixes I forgot to commit

### DIFF
--- a/inc/drivers/HIDMouse.h
+++ b/inc/drivers/HIDMouse.h
@@ -33,8 +33,8 @@ namespace codal
 {
     typedef enum {
         HID_MOUSE_RIGHT = 0x01,
-        HID_MOUSE_MIDDLE = 0x02,
-        HID_MOUSE_LEFT = 0x04,
+        HID_MOUSE_MIDDLE = 0x04,
+        HID_MOUSE_LEFT = 0x02,
     } USBHIDMouseButton;
 
     typedef union {

--- a/source/drivers/HIDJoystick.cpp
+++ b/source/drivers/HIDJoystick.cpp
@@ -192,12 +192,6 @@ int USBHIDJoystick::sendReport()
 	uint8_t report[sizeof(HIDJoystickState)];
 	memcpy(report, &joystickState, sizeof(HIDJoystickState));
 
-	//movements are relative
-	joystickState.x0 = 0;
-	joystickState.y0 = 0;
-	joystickState.x1 = 0;
-	joystickState.y1 = 0;
-
 	return in->write(report, sizeof(report));
 }
 


### PR DESCRIPTION
left and middle mouse button enum was backwards and I had fixed some joystick stuff a while ago that I forgot to push.