### PR TITLE
Add last_ptr field to heap definition to speed up allocation

### DIFF
--- a/inc/core/CodalHeapAllocator.h
+++ b/inc/core/CodalHeapAllocator.h
@@ -59,7 +59,8 @@ DEALINGS IN THE SOFTWARE.
 struct HeapDefinition
 {
     PROCESSOR_WORD_TYPE *heap_start;		// Physical address of the start of this heap.
-    PROCESSOR_WORD_TYPE *heap_end;		    // Physical address of the end of this heap.
+    PROCESSOR_WORD_TYPE *heap_end;		  // Physical address of the end of this heap.
+    PROCESSOR_WORD_TYPE *last_ptr;		  // Most recent location to start scanning from.
 };
 extern PROCESSOR_WORD_TYPE codal_heap_start;
 


### PR DESCRIPTION
@finneyj what do you think about this? The idea is to speed up allocation on large heaps (and it does, motivation is https://benchmarksgame-team.pages.debian.net/benchmarksgame/program/binarytrees-gcc-1.html ). It may increase fragmentation, or I guess it may not. What the actual scenario you were trying to fix with the first-fit algorithm?