### PR TITLE
Add target_wait_us in codal_target_hal.h

### DIFF
--- a/inc/core/codal_target_hal.h
+++ b/inc/core/codal_target_hal.h
@@ -36,6 +36,8 @@ extern "C"
     void target_reset();
 
     void target_wait(unsigned long milliseconds);
+    
+    void target_wait_us(unsigned long us);
 
     void target_wait_for_event();
 


### PR DESCRIPTION
I just adding the profile of this function which seems to be defined in all codal target. Since it is defined in the codal_target_hal.c  file, it seems relevant that it must be declared in the corresponding header file.