### PR TITLE
Add codal::list_fibers() API; prevent FOB when user_data set

### DIFF
--- a/inc/core/CodalFiber.h
+++ b/inc/core/CodalFiber.h
@@ -321,6 +321,15 @@ namespace codal
       * This function typically calls idle().
       */
     void idle_task();
+
+    /**
+      * Return all current fibers.
+      *
+      * @param dest If non-null, it points to an array of pointers to fibers to store results in.
+      *
+      * @return the number of fibers (potentially) stored
+      */
+    int list_fibers(Fiber **dest);
 }
 
 

--- a/source/core/CodalFiber.cpp
+++ b/source/core/CodalFiber.cpp
@@ -519,8 +519,8 @@ int codal::invoke(void (*entry_fn)(void))
 
     if (currentFiber->flags & (DEVICE_FIBER_FLAG_FOB | DEVICE_FIBER_FLAG_PARENT | DEVICE_FIBER_FLAG_CHILD) || HAS_THREAD_USER_DATA)
     {
-        // If we attempt a fork on block whilst already in  fork n block context,
-        // simply launch a fiber to deal with the request and we're done.
+        // If we attempt a fork on block whilst already in a fork on block context, or if the thread 
+        // already has user data set, simply launch a fiber to deal with the request and we're done.
         create_fiber(entry_fn);
         return DEVICE_OK;
     }
@@ -585,8 +585,8 @@ int codal::invoke(void (*entry_fn)(void *), void *param)
 
     if (currentFiber->flags & (DEVICE_FIBER_FLAG_FOB | DEVICE_FIBER_FLAG_PARENT | DEVICE_FIBER_FLAG_CHILD) || HAS_THREAD_USER_DATA)
     {
-        // If we attempt a fork on block whilst already in a fork on block context,
-        // simply launch a fiber to deal with the request and we're done.
+        // If we attempt a fork on block whilst already in a fork on block context, or if the thread 
+        // already has user data set, simply launch a fiber to deal with the request and we're done.
         create_fiber(entry_fn, param);
         return DEVICE_OK;
     }


### PR DESCRIPTION
I used to keep back-pointer to codal fiber from my user data, and list on my side, but this doesn't work with FOB, since the fiber pointer changes.

Thus, I need to get the list of fibers directly from Codal.

I also refactored the FOB handling to a function, and prevented usage of FOB and user_data at the same time (it breaks).