### PR TITLE
Jacdac

### DIFF
--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -267,14 +267,17 @@ int JDLogicDriver::handlePacket(JDPkt* p)
             if (current->device.flags & JD_DEVICE_FLAGS_INITIALISED)
             {
                 // ONLY ADD BROADCAST MAPS IF THE DRIVER IS INITIALISED.
-                int j;
+                bool exists = false;
 
-                for (j = 0; j < JD_PROTOCOL_DRIVER_ARRAY_SIZE; j++)
-                    if (JDProtocol::instance->drivers[i]->device.address == cp->address && JDProtocol::instance->drivers[i]->device.serial_number ==cp->serial_number)
+                for (int j = 0; j < JD_PROTOCOL_DRIVER_ARRAY_SIZE; j++)
+                    if (JDProtocol::instance->drivers[j]->device.address == cp->address && JDProtocol::instance->drivers[j]->device.serial_number == cp->serial_number)
+                    {
+                        exists = true;
                         break;
+                    }
 
                 // only add a broadcast device if it is not already represented in the driver array.
-                if (j == JD_PROTOCOL_DRIVER_ARRAY_SIZE)
+                if (!exists)
                 {
                     JD_DMESG("ADD NEW MAP");
                     new JDDriver(JDDevice(cp->address, cp->flags | JD_DEVICE_FLAGS_BROADCAST_MAP | JD_DEVICE_FLAGS_INITIALISED, cp->serial_number, cp->driver_class));

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -165,7 +165,7 @@ int JDLogicDriver::handlePacket(JDPkt* p)
 {
     ControlPacket *cp = (ControlPacket *)p->data;
 
-     JD_DMESG("CP Add %d, Ser %d, Class %d pair: %d", cp->address, cp->serial_number, cp->driver_class, (cp->flags & CONTROL_JD_FLAGS_PAIRING_MODE) ? 1 : 0);
+     JD_DMESG("CP A:%d S:%d C:%d p: %d", cp->address, cp->serial_number, cp->driver_class, (cp->flags & CONTROL_JD_FLAGS_PAIRING_MODE) ? 1 : 0);
 
     // Logic Driver addressing rules:
     // 1. drivers cannot have the same address and different serial numbers.
@@ -270,7 +270,7 @@ int JDLogicDriver::handlePacket(JDPkt* p)
                 int j;
 
                 for (j = 0; j < JD_PROTOCOL_DRIVER_ARRAY_SIZE; j++)
-                    if (JDProtocol::instance->drivers[i]->device.serial_number ==cp->serial_number)
+                    if (JDProtocol::instance->drivers[i]->device.address == cp->address && JDProtocol::instance->drivers[i]->device.serial_number ==cp->serial_number)
                         break;
 
                 // only add a broadcast device if it is not already represented in the driver array.

--- a/source/JACDAC/JDMessageBusDriver.cpp
+++ b/source/JACDAC/JDMessageBusDriver.cpp
@@ -101,8 +101,6 @@ int JDMessageBusDriver::handlePacket(JDPkt* p)
 {
     Event *e = (Event *) p->data;
 
-    DMESG("EV: %d, %d", e->source, e->value);
-
     suppressForwarding = true;
     e->fire();
     suppressForwarding = false;

--- a/source/JACDAC/JDMessageBusDriver.cpp
+++ b/source/JACDAC/JDMessageBusDriver.cpp
@@ -122,11 +122,11 @@ int JDMessageBusDriver::handleControlPacket(JDPkt*)
   */
 void JDMessageBusDriver::eventReceived(Event e)
 {
-    DMESG("EVENT");
+    // DMESG("EVENT");
     if(suppressForwarding)
         return;
 
-    DMESG("PACKET QUEUED: %d %d %d", e.source, e.value, sizeof(Event));
+    // DMESG("PACKET QUEUED: %d %d %d", e.source, e.value, sizeof(Event));
     int ret = JDProtocol::send((uint8_t *)&e, sizeof(Event), device.address);
-    DMESG("RET %d",ret);
+    // DMESG("RET %d",ret);
 }


### PR DESCRIPTION
@pelikhan @mmoskal bugfixes you will want:

* Fixed tons of broadcast stubs being created because I used `i` instead of `j` to index the driver array.
* Prevents the use of JACDAC before start has been called.