### PR TITLE
add WIP draft of a debug function for JACDAC

### DIFF
--- a/inc/JACDAC/JACDAC.h
+++ b/inc/JACDAC/JACDAC.h
@@ -96,6 +96,15 @@ namespace codal
 
         JDPkt* next;
     } __attribute((__packed__));
+
+    enum class JACDACBusState : uint8_t
+    {
+        Receiving,
+        Transmitting,
+        High,
+        Low
+    };
+
     /**
     * Class definition for a JACDAC interface.
     */
@@ -188,7 +197,25 @@ namespace codal
           */
         virtual int send(uint8_t* buf, int len, uint8_t address);
 
+        /**
+         * Returns a bool indicating whether the JACDAC driver has been started.
+         *
+         * @return true if started, false if not.
+         **/
         bool isRunning();
+
+        /**
+         * Returns the current state of the bus, either:
+         *
+         * * Receiving if the driver is in the process of receiving a packet.
+         * * Transmitting if the driver is communicating a packet on the bus.
+         *
+         * If neither of the previous states are true, then the driver looks at the bus and returns the bus state:
+         *
+         * * High, if the line is currently floating high.
+         * * Lo if something is currently pulling the line low.
+         **/
+        JACDACBusState getState();
     };
 } // namespace codal
 

--- a/inc/JACDAC/JDProtocol.h
+++ b/inc/JACDAC/JDProtocol.h
@@ -30,6 +30,7 @@ DEALINGS IN THE SOFTWARE.
 #include "ErrorNo.h"
 #include "Event.h"
 #include "JACDAC.h"
+#include "JackRouter.h"
 #include "codal_target_hal.h"
 
 
@@ -703,6 +704,13 @@ namespace codal
          * @return DEVICE_OK on success.
          **/
         static int send(uint8_t* buf, int len, uint8_t address);
+
+        /**
+         * Logs the current state of JACDAC, drivers, and the jackrouter (if provided).
+         *
+         * @param jr The jack router in use.
+         **/
+        void logState(JackRouter* jr = NULL);
     };
 
 } // namespace codal

--- a/source/JACDAC/JDProtocol.cpp
+++ b/source/JACDAC/JDProtocol.cpp
@@ -173,3 +173,74 @@ int JDProtocol::send(uint8_t* buf, int len, uint8_t address)
 
     return DEVICE_NO_RESOURCES;
 }
+
+
+void JDProtocol::logState(JackRouter* jr)
+{
+    if (JDProtocol::instance == NULL)
+        return;
+
+    DMESG("Enabled: %d", JDProtocol::instance->bus.isRunning());
+
+
+    JACDACBusState busState = JDProtocol::instance->bus.getState();
+
+    const char* busStateStr = "";
+
+    switch(busState)
+    {
+        case JACDACBusState::Receiving:
+            busStateStr = "Receiving";
+            break;
+
+        case JACDACBusState::Transmitting:
+            busStateStr = "Transmitting";
+            break;
+
+        case JACDACBusState::High:
+            busStateStr = "High";
+            break;
+
+        case JACDACBusState::Low:
+            busStateStr = "Low";
+            break;
+    }
+
+    DMESG("Bus state: %s", busStateStr);
+
+    const char* jackRouterStateStr = "";
+
+    if (jr)
+    {
+        JackState s = jr->getState();
+
+        switch (s)
+        {
+            case JackState::None:
+                jackRouterStateStr = "None";
+                break;
+            case JackState::AllDown:
+                jackRouterStateStr = "AllDown";
+                break;
+            case JackState::HeadPhones:
+                jackRouterStateStr = "HeadPhones";
+                break;
+            case JackState::Buzzer:
+                jackRouterStateStr = "Buzzer";
+                break;
+            case JackState::BuzzerAndSerial:
+                jackRouterStateStr = "BuzzerAndSerial";
+                break;
+        }
+
+        DMESG("Router state: %s", jackRouterStateStr);
+    }
+
+    for (int i = 0; i < JD_PROTOCOL_DRIVER_ARRAY_SIZE; i++)
+    {
+        JDDriver* current = JDProtocol::instance->drivers[i];
+
+        if (current)
+            DMESG("Driver %d initialised[%d] address[%d] serial[%d] class[%d], mode[%s%s%s]", i, current->isConnected(), current->device.address, current->device.serial_number, current->device.driver_class, current->device.flags & JD_DEVICE_FLAGS_BROADCAST ? "B" : "", current->device.flags & JD_DEVICE_FLAGS_LOCAL ? "L" : "", current->device.flags & JD_DEVICE_FLAGS_REMOTE ? "R" : "");
+    }
+}


### PR DESCRIPTION
@pelikhan 

use as follows:

```cpp
protocol.logState(&bp.jackRouter); // with jack router debug
```

or 

```cpp
protocol.logState(); // without jack router debug
```