### PR TITLE
Jacdac protocol errors

### DIFF
--- a/inc/JACDAC/JDProtocol.h
+++ b/inc/JACDAC/JDProtocol.h
@@ -85,6 +85,7 @@ DEALINGS IN THE SOFTWARE.
 
 #define CONTROL_JD_TYPE_HELLO                   0x01
 #define CONTROL_JD_TYPE_PAIRING_REQUEST         0x02
+#define CONTROL_JD_TYPE_PANIC                   0x03
 // END      LOGIC DRIVER FLAGS
 
 
@@ -96,7 +97,8 @@ DEALINGS IN THE SOFTWARE.
 
 // END      JD SERIAL PROTOCOL
 
-#define CONTROL_PACKET_PAYLOAD_SIZE     (JD_SERIAL_DATA_SIZE - 12)
+#define CONTROL_PACKET_PANIC_NAME_LENGTH        6
+#define CONTROL_PACKET_PAYLOAD_SIZE             (JD_SERIAL_DATA_SIZE - 12)
 
 namespace codal
 {
@@ -119,7 +121,14 @@ namespace codal
         uint32_t driver_class;  // the class of the driver
         uint32_t serial_number; // the "unique" serial number of the device.
         uint8_t data[CONTROL_PACKET_PAYLOAD_SIZE];
-    }__attribute((__packed__));
+    } __attribute((__packed__));
+
+    // this struct sits inside the data of a normal contrl packet if the packet_type is set to PANIC.
+    struct ControlPacketPanic
+    {
+        char name[CONTROL_PACKET_PANIC_NAME_LENGTH];
+        int code;
+    } __attribute((__packed__));
 
     // This enumeration specifies that supported configurations that drivers should utilise.
     // Many combinations of flags are supported, but only the ones listed here have been fully implemented.

--- a/inc/JACDAC/JDProtocol.h
+++ b/inc/JACDAC/JDProtocol.h
@@ -31,6 +31,7 @@ DEALINGS IN THE SOFTWARE.
 #include "Event.h"
 #include "JACDAC.h"
 #include "JackRouter.h"
+#include "ManagedString.h"
 #include "codal_target_hal.h"
 
 
@@ -43,6 +44,7 @@ DEALINGS IN THE SOFTWARE.
 #define JD_DRIVER_EVT_UNPAIRED          65523
 #define JD_DRIVER_EVT_PAIR_REJECTED     65524
 #define JD_DRIVER_EVT_PAIRING_RESPONSE  65525
+#define JD_DRIVER_EVT_ERROR             65526
 
 #define JD_DEVICE_FLAGS_LOCAL           0x8000 // on the board
 #define JD_DEVICE_FLAGS_REMOTE          0x4000 // off the board
@@ -62,6 +64,9 @@ DEALINGS IN THE SOFTWARE.
 #define JD_DEVICE_FLAGS_INITIALISING    0x0040 // a flag to indicate that a control packet has been queued
 #define JD_DEVICE_FLAGS_CP_SEEN         0x0020 // indicates whether a control packet has been seen recently.
 #define JD_DEVICE_FLAGS_BROADCAST_MAP   0x0010 // This driver is held for mapping from bus address to driver class
+
+#define JD_DEVICE_ERROR_MSK             0x000F // the lower 4 bits are reserved for well known errors, these are
+                                               // automatically placed into control packets by the logic driver.
 // END      JD SERIAL DRIVER FLAGS
 
 
@@ -85,7 +90,8 @@ DEALINGS IN THE SOFTWARE.
 
 #define CONTROL_JD_TYPE_HELLO                   0x01
 #define CONTROL_JD_TYPE_PAIRING_REQUEST         0x02
-#define CONTROL_JD_TYPE_PANIC                   0x03
+#define CONTROL_JD_TYPE_ERROR                   0x03 // routed to drivers
+#define CONTROL_JD_TYPE_PANIC                   0xFF
 // END      LOGIC DRIVER FLAGS
 
 
@@ -97,8 +103,8 @@ DEALINGS IN THE SOFTWARE.
 
 // END      JD SERIAL PROTOCOL
 
-#define CONTROL_PACKET_PANIC_NAME_LENGTH        6
 #define CONTROL_PACKET_PAYLOAD_SIZE             (JD_SERIAL_DATA_SIZE - 12)
+#define CONTROL_PACKET_ERROR_NAME_LENGTH        6
 
 namespace codal
 {
@@ -123,10 +129,10 @@ namespace codal
         uint8_t data[CONTROL_PACKET_PAYLOAD_SIZE];
     } __attribute((__packed__));
 
-    // this struct sits inside the data of a normal contrl packet if the packet_type is set to PANIC.
-    struct ControlPacketPanic
+    // this struct sits inside the data of a normal control packet if the packet_type is set to ERROR.
+    struct ControlPacketError
     {
-        char name[CONTROL_PACKET_PANIC_NAME_LENGTH];
+        char name[CONTROL_PACKET_ERROR_NAME_LENGTH];
         int code;
     } __attribute((__packed__));
 
@@ -140,6 +146,13 @@ namespace codal
         PairableHostDriver = JD_DEVICE_FLAGS_PAIRABLE | JD_DEVICE_FLAGS_LOCAL, // the driver is allowed to pair with another driver of the same class
         BroadcastDriver = JD_DEVICE_FLAGS_LOCAL | JD_DEVICE_FLAGS_BROADCAST, // the driver is enumerated with its own address, and receives all packets of the same class (including control packets)
         SnifferDriver = JD_DEVICE_FLAGS_REMOTE | JD_DEVICE_FLAGS_BROADCAST, // the driver is not enumerated, and receives all packets of the same class (including control packets)
+    };
+
+    enum DriverErrorCode
+    {
+        STATUS_OK,
+        PERIPHERAL_MALFUNCTION,
+
     };
 
     /**
@@ -239,6 +252,27 @@ namespace codal
                 this->flags |= JD_DEVICE_FLAGS_INITIALISED;
             else
                 this->flags &= ~JD_DEVICE_FLAGS_INITIALISED;
+        }
+
+        /**
+         * Sets the error portion of flags to the given error code
+         *
+         * @param e the error code to place into control packets
+         **/
+        void setError(DriverErrorCode e)
+        {
+            uint32_t flags = this->flags & ~(JD_DEVICE_ERROR_MSK);
+            this->flags = flags | (uint8_t) e;
+        }
+
+        /**
+         * Retrieves the current error code from the error portion of flags.
+         *
+         * @return a JDDeviceErrorCode
+         **/
+        DriverErrorCode getError()
+        {
+            return (DriverErrorCode)(this->flags & JD_DEVICE_ERROR_MSK);
         }
 
         /**
@@ -438,6 +472,18 @@ namespace codal
          *         should continue to search for a driver.
          **/
         virtual int handleControlPacket(JDPkt* p);
+
+        /**
+         * Invoked by the logic driver when a control packet with its type set to error is received.
+         *
+         *
+         * @param p the packet from the serial bus. Drivers should cast p->data to a ControlPacket,
+         *          then ControlPacket->data to ControlPacketError to obtain the error code.
+         *
+         * @return DEVICE_OK to signal that the packet has been handled, or DEVICE_CANCELLED to indicate the logic driver
+         *         should continue to search for a driver.
+         **/
+        virtual int handleErrorPacket(JDPkt* p);
 
         /**
          * Invoked by the logic driver when a pairing packet with the address of the driver is received.
@@ -682,6 +728,22 @@ namespace codal
          *       Ultimately the bridge should punt packets back intro JDProtocol for correct handling.
          **/
         int setBridge(JDDriver* bridge);
+
+        /**
+         * Set the name to use for error codes and panics
+         *
+         * @param s the name to use for error codes and panic's
+         *
+         * @note Must be 6 characters or smaller.
+         **/
+        static int setDebugName(ManagedString s);
+
+        /**
+         * Retrieve the name used for error codes and panics
+         *
+         * @return the name used for error codes and panics
+         **/
+        static ManagedString getDebugName();
 
         /**
          * Adds a driver to the drivers array. The logic driver iterates over this array.

--- a/source/JACDAC/JDDriver.cpp
+++ b/source/JACDAC/JDDriver.cpp
@@ -80,6 +80,9 @@ int JDDriver::handleLogicPacket(JDPkt* p)
     if (cp->packet_type == CONTROL_JD_TYPE_PAIRING_REQUEST)
         return this->handlePairingPacket(p);
 
+    if (cp->packet_type == CONTROL_JD_TYPE_ERROR)
+        return this->handleErrorPacket(p);
+
     return this->handleControlPacket(p);
 }
 
@@ -280,6 +283,12 @@ void JDDriver::partnerDisconnected(Event)
 
 int JDDriver::handleControlPacket(JDPkt* p)
 {
+    return DEVICE_OK;
+}
+
+int JDDriver::handleErrorPacket(JDPkt* p)
+{
+    Event(this->id, JD_DRIVER_EVT_ERROR);
     return DEVICE_OK;
 }
 

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -167,6 +167,16 @@ int JDLogicDriver::handlePacket(JDPkt* p)
 {
     ControlPacket *cp = (ControlPacket *)p->data;
 
+    if (cp->type == CONTROL_JD_TYPE_PANIC)
+    {
+        ControlPacketPanic* panic = (ControlPacketPanic*)p->data;
+        char name[CONTROL_PACKET_PANIC_NAME_LENGTH + 1] = { 0 };
+        memcpy(name, panic, CONTROL_PACKET_PANIC_NAME_LENGTH);
+        name[CONTROL_PACKET_PANIC_NAME_LENGTH] = 0;
+        DMESG("PANIC: %s, STATUS: %d", name, panic->status);
+        return;
+    }
+
      JD_DMESG("CP A:%d S:%d C:%d p: %d", cp->address, cp->serial_number, cp->driver_class, (cp->flags & CONTROL_JD_FLAGS_PAIRING_MODE) ? 1 : 0);
 
     // Logic Driver addressing rules:

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -21,6 +21,22 @@ void JDLogicDriver::populateControlPacket(JDDriver* driver, ControlPacket* cp)
 
     cp->driver_class = driver->device.driver_class;
     cp->serial_number = driver->device.serial_number;
+
+    int error = driver->device.getError();
+
+    // todo: eventually we will swap to variable packet sizes.
+    // This code will need to be updated to return the size of the control packet dependent on cp type...
+    if (error > 0)
+    {
+        cp->packet_type = CONTROL_JD_TYPE_ERROR;
+
+        ControlPacketError* err = (ControlPacketError *)cp->data;
+        memset(err, 0, sizeof(ControlPacketError));
+
+        ManagedString s = JDProtocol::getDebugName();
+        memcpy(err->name,s.toCharArray(),min(s.length(), CONTROL_PACKET_ERROR_NAME_LENGTH));
+        err->code = error;
+    }
 }
 
 void JDLogicDriver::periodicCallback()
@@ -167,14 +183,16 @@ int JDLogicDriver::handlePacket(JDPkt* p)
 {
     ControlPacket *cp = (ControlPacket *)p->data;
 
-    if (cp->type == CONTROL_JD_TYPE_PANIC)
+    if (cp->packet_type == CONTROL_JD_TYPE_PANIC)
     {
-        ControlPacketPanic* panic = (ControlPacketPanic*)p->data;
-        char name[CONTROL_PACKET_PANIC_NAME_LENGTH + 1] = { 0 };
-        memcpy(name, panic, CONTROL_PACKET_PANIC_NAME_LENGTH);
-        name[CONTROL_PACKET_PANIC_NAME_LENGTH] = 0;
-        DMESG("PANIC: %s, STATUS: %d", name, panic->status);
-        return;
+        ControlPacketError* error = (ControlPacketError*)p->data;
+
+        char name[CONTROL_PACKET_ERROR_NAME_LENGTH + 1] = { 0 };
+        memcpy(name, error, CONTROL_PACKET_ERROR_NAME_LENGTH);
+        name[CONTROL_PACKET_ERROR_NAME_LENGTH] = 0;
+
+        DMESG("%s is panicking [%d]", name, error->code);
+        return DEVICE_OK;
     }
 
      JD_DMESG("CP A:%d S:%d C:%d p: %d", cp->address, cp->serial_number, cp->driver_class, (cp->flags & CONTROL_JD_FLAGS_PAIRING_MODE) ? 1 : 0);

--- a/source/JACDAC/JDProtocol.cpp
+++ b/source/JACDAC/JDProtocol.cpp
@@ -34,6 +34,8 @@ using namespace codal;
 
 JDDriver* JDProtocol::drivers[JD_PROTOCOL_DRIVER_ARRAY_SIZE] = { 0 };
 
+static char jacdac_name[CONTROL_PACKET_PANIC_NAME_LENGTH] = "JACDAC";
+
 JDProtocol* JDProtocol::instance = NULL;
 
 void JDProtocol::onPacketReceived(Event)
@@ -174,6 +176,19 @@ int JDProtocol::send(uint8_t* buf, int len, uint8_t address)
     return DEVICE_NO_RESOURCES;
 }
 
+int JDProtocol::setName(ManagedString s)
+{
+    if (s.length() > CONTROL_PACKET_PANIC_NAME_LENGTH)
+        return DEVICE_INVALID_PARAMETER;
+
+    memcpy(jacdac_name, s.toCharArray(), s.length());
+    return DEVICE_OK;
+}
+
+ManagedString& JDProtocol::getName(ManagedString s)
+{
+    return ManagedString(jacdac_name, CONTROL_PACKET_PANIC_NAME_LENGTH);
+}
 
 void JDProtocol::logState(JackRouter* jr)
 {

--- a/source/JACDAC/JDProtocol.cpp
+++ b/source/JACDAC/JDProtocol.cpp
@@ -30,11 +30,11 @@ DEALINGS IN THE SOFTWARE.
 #include "Timer.h"
 #include "CodalDmesg.h"
 
+static char jacdac_name[CONTROL_PACKET_ERROR_NAME_LENGTH] = {'J', 'A', 'C', 'D', 'A', 'C'};
+
 using namespace codal;
 
 JDDriver* JDProtocol::drivers[JD_PROTOCOL_DRIVER_ARRAY_SIZE] = { 0 };
-
-static char jacdac_name[CONTROL_PACKET_PANIC_NAME_LENGTH] = "JACDAC";
 
 JDProtocol* JDProtocol::instance = NULL;
 
@@ -177,18 +177,18 @@ int JDProtocol::send(uint8_t* buf, int len, uint8_t address)
     return DEVICE_NO_RESOURCES;
 }
 
-int JDProtocol::setName(ManagedString s)
+int JDProtocol::setDebugName(ManagedString s)
 {
-    if (s.length() > CONTROL_PACKET_PANIC_NAME_LENGTH)
+    if (s.length() > CONTROL_PACKET_ERROR_NAME_LENGTH)
         return DEVICE_INVALID_PARAMETER;
 
     memcpy(jacdac_name, s.toCharArray(), s.length());
     return DEVICE_OK;
 }
 
-ManagedString& JDProtocol::getName(ManagedString s)
+ManagedString JDProtocol::getDebugName()
 {
-    return ManagedString(jacdac_name, CONTROL_PACKET_PANIC_NAME_LENGTH);
+    return ManagedString(jacdac_name, CONTROL_PACKET_ERROR_NAME_LENGTH);
 }
 
 void JDProtocol::logState(JackRouter* jr)


### PR DESCRIPTION
@pelikhan @teddyseyed @mmoskal 

This PR introduces a new control packet type: `ERROR`. It also adds a new interface to a JDDriver `handleErrorPacket`, which is invoked when a control packet flagging an error is received.

Error codes are automatically placed into control packets by the logic driver based on the JDDevice state in a driver. To set an error code call `driver.device.setError(ERR_CODE)`. Protocol error codes are limited to 16 numbers (4 bits), time will tell if this is enough error codes...

JDProtocol now accepts a debugging name that is placed in the control packet when an error is flagged: `JDProtocol::setDebugName`, you can also retrieve the current debug name using `JDProtocol::getDebugName`. Currently it's one debug name per device, rather than per driver. I might take it out, as i'm not sure how useful it is.

I've only added two error codes at the moment `STATUS_OK` and `PERIPHERAL_MALFUNCTION`. I'm the list will grow as we move forward.

An example is shown below:

```cpp
struct JDTestPacket
{
    uint8_t x;
    uint8_t y;
} __attribute((__packed__));

class JDHostTest : public JDDriver
{
    public:
    JDHostTest() : JDDriver(JDDevice(HostDriver, 10)) {}

    void send()
    {
        JDTestPacket tp;

        tp.x = target_random(255);
        tp.y = target_random(255);

        JDProtocol::send((uint8_t*)&tp, sizeof(tp), this->device.address);
    }

    void setError()
    {
        this->device.setError(PERIPHERAL_MALFUNCTION);
    }
};


class JDVirtualTest : public JDDriver
{
    public:
    JDVirtualTest() : JDDriver(JDDevice(VirtualDriver, 10)) {}

    int handlePacket(JDPkt* packet)
    {
        JDTestPacket* tp = (JDTestPacket*)packet->data;
        DMESG("REC: x %d y %d",tp->x, tp->y);
        Event(9999,999);
        return DEVICE_OK;
    }

    int handleErrorPacket(JDPkt* p)
    {
        ControlPacket* cp = (ControlPacket*)p->data;
        ControlPacketError* err = (ControlPacketError*)cp->data;

        char name[CONTROL_PACKET_ERROR_NAME_LENGTH + 1] = { 0 };
        memcpy(name, err, CONTROL_PACKET_ERROR_NAME_LENGTH);
        name[CONTROL_PACKET_ERROR_NAME_LENGTH] = 0;

        DMESG("ERROR: %s %d", name, err->code);
        return DEVICE_OK;
    }
};
```