### PR TITLE
allow for plugging in an external memory allocator

### DIFF
--- a/inc/core/CodalHeapAllocator.h
+++ b/inc/core/CodalHeapAllocator.h
@@ -107,4 +107,12 @@ extern "C" void* device_malloc(size_t size);
   */
 extern "C" void device_free(void *mem);
 
+/**
+  * Copy existing contents of ptr to a new memory block of given size.
+  *
+  * @param ptr The existing memory block (can be NULL)
+  * @param size The size of new block (can be smaller or larger than the old one)
+  */
+extern "C" void* device_realloc(void* ptr, size_t size);
+
 #endif

--- a/inc/core/CodalHeapAllocator.h
+++ b/inc/core/CodalHeapAllocator.h
@@ -90,4 +90,21 @@ int device_create_heap(PROCESSOR_WORD_TYPE start, PROCESSOR_WORD_TYPE end);
  */
 uint32_t device_heap_size(uint8_t heap_index);
 
+
+/**
+  * Attempt to allocate a given amount of memory from any of our configured heap areas.
+  *
+  * @param size The amount of memory, in bytes, to allocate.
+  *
+  * @return A pointer to the allocated memory, or NULL if insufficient memory is available.
+  */
+extern "C" void* device_malloc(size_t size);
+
+/**
+  * Release a given area of memory from the heap.
+  *
+  * @param mem The memory area to release.
+  */
+extern "C" void device_free(void *mem);
+
 #endif


### PR DESCRIPTION
* prefix `malloc()`, `free()`, and `realloc()` with `device_*`
* define the plain versions as weak aliases of  `device_*` versions
* make sure `currentFiber` is set properly when calling memory allocator from the stack verification routine
* bugfix in `calloc()`
* limit number of fibers in the pool to 3

This lets me re-define `malloc()` to use the same heap as my GC. I still direct allocations in ISR to `device_malloc()`. This follows @finneyj suggestion of a separate heap for ISRs - my GC allocates most of the Codal's heap for its own heap and what's left is the "ISR heap". The ISR is also used for temporary structures of the GC.
