### PR TITLE
Apply patch for broadcast driver disconnection

### DIFF
--- a/inc/JACDAC/JDProtocol.h
+++ b/inc/JACDAC/JDProtocol.h
@@ -63,7 +63,6 @@ DEALINGS IN THE SOFTWARE.
 #define JD_DEVICE_FLAGS_INITIALISED     0x0080 // device driver is running
 #define JD_DEVICE_FLAGS_INITIALISING    0x0040 // a flag to indicate that a control packet has been queued
 #define JD_DEVICE_FLAGS_CP_SEEN         0x0020 // indicates whether a control packet has been seen recently.
-#define JD_DEVICE_FLAGS_BROADCAST_MAP   0x0010 // This driver is held for mapping from bus address to driver class
 
 #define JD_DEVICE_ERROR_MSK             0x000F // the lower 4 bits are reserved for well known errors, these are
                                                // automatically placed into control packets by the logic driver.

--- a/inc/JACDAC/JDProtocol.h
+++ b/inc/JACDAC/JDProtocol.h
@@ -795,9 +795,9 @@ namespace codal
     };
 
     /**
-     * This class is a stub of a remote driver that a local driver is paired with.
+     * This class is a simple packet forwarder for broadcast packets.
      *
-     * It simply forwards all standard packets to the paired local driver for processing.
+     * It is responsible for forwarding all packets to other drivers of the same class.
      **/
     class JDBroadcastMap : public JDDriver
     {

--- a/source/JACDAC/JDDriver.cpp
+++ b/source/JACDAC/JDDriver.cpp
@@ -105,7 +105,7 @@ bool JDDriver::isConnected()
 
 int JDDriver::deviceConnected(JDDevice device)
 {
-    DMESG("CONNECTED a:%d sn:%d cl:%d",device.address,device.serial_number, device.driver_class);
+    // DMESG("CONNB a:%d sn:%d cl:%d",device.address,device.serial_number, device.driver_class);
     this->device.address = device.address;
     this->device.serial_number = device.serial_number;
     this->device.flags |= JD_DEVICE_FLAGS_INITIALISED | JD_DEVICE_FLAGS_CP_SEEN;
@@ -120,7 +120,7 @@ int JDDriver::deviceConnected(JDDevice device)
 
 int JDDriver::deviceRemoved()
 {
-    DMESG("DISCONN a:%d sn:%d cl: %d",device.address,device.serial_number, device.driver_class);
+    // DMESG("DISCB a:%d sn:%d cl: %d",device.address,device.serial_number, device.driver_class);
     this->device.flags &= ~(JD_DEVICE_FLAGS_INITIALISED);
     this->device.rolling_counter = 0;
     Event(this->id, JD_DRIVER_EVT_DISCONNECTED);
@@ -288,6 +288,9 @@ int JDDriver::handleControlPacket(JDPkt* p)
 
 int JDDriver::handleErrorPacket(JDPkt* p)
 {
+    ControlPacket* cp = (ControlPacket*)p->data;
+    ControlPacketError* err = (ControlPacketError*)cp->data;
+    this->device.setError((DriverErrorCode)err->code);
     Event(this->id, JD_DRIVER_EVT_ERROR);
     return DEVICE_OK;
 }

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -59,7 +59,7 @@ void JDLogicDriver::periodicCallback()
             current->device.rolling_counter++;
 
         // if the driver is acting as a virtual driver, we don't need to perform any initialisation, just connect / disconnect events.
-        if (current->device.flags & JD_DEVICE_FLAGS_REMOTE)
+        if (current->device.flags & (JD_DEVICE_FLAGS_REMOTE | JD_DEVICE_FLAGS_BROADCAST_MAP))
         {
             if (current->device.rolling_counter == JD_LOGIC_DRIVER_TIMEOUT)
             {
@@ -68,6 +68,13 @@ void JDLogicDriver::periodicCallback()
                     JD_DMESG("CONTROL NOT SEEN %d %d", current->device.address, current->device.serial_number);
                     current->deviceRemoved();
                     Event(this->id, JD_LOGIC_DRIVER_EVT_CHANGED);
+
+                    if (current->device.flags & JD_DEVICE_FLAGS_BROADCAST_MAP)
+                    {
+                        JDProtocol::instance->remove(*current);
+                        delete current;
+                        continue;
+                    }
                 }
 
                 current->device.flags &= ~(JD_DEVICE_FLAGS_CP_SEEN);

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -320,7 +320,7 @@ int JDLogicDriver::handlePacket(JDPkt* p)
     {
         JD_DMESG("ADD NEW MAP");
         JD_DMESG("BROADCAST ADD %d", cp->address);
-        new JDDriver(JDDevice(cp->address, JD_DEVICE_FLAGS_BROADCAST | JD_DEVICE_FLAGS_REMOTE | JD_DEVICE_FLAGS_INITIALISED | JD_DEVICE_FLAGS_CP_SEEN, cp->serial_number, cp->driver_class));
+        new JDBroadcastMap(cp->address, cp->serial_number, cp->driver_class);
         Event(this->id, JD_LOGIC_DRIVER_EVT_CHANGED);
     }
 

--- a/source/JACDAC/JDLogicDriver.cpp
+++ b/source/JACDAC/JDLogicDriver.cpp
@@ -59,7 +59,7 @@ void JDLogicDriver::periodicCallback()
             current->device.rolling_counter++;
 
         // if the driver is acting as a virtual driver, we don't need to perform any initialisation, just connect / disconnect events.
-        if (current->device.flags & (JD_DEVICE_FLAGS_REMOTE | JD_DEVICE_FLAGS_BROADCAST) && !(current->device.flags & JD_DEVICE_FLAGS_LOCAL))
+        if (current->device.flags & JD_DEVICE_FLAGS_REMOTE)
         {
             if (current->device.rolling_counter == JD_LOGIC_DRIVER_TIMEOUT)
             {

--- a/source/JACDAC/JDProtocol.cpp
+++ b/source/JACDAC/JDProtocol.cpp
@@ -61,7 +61,7 @@ void JDProtocol::onPacketReceived(Event)
                     JD_DMESG("DRIV a:%d sn:%d i:%d f %d", this->drivers[i]->device.address, this->drivers[i]->device.serial_number, this->drivers[i]->device.flags & JD_DEVICE_FLAGS_INITIALISED ? 1 : 0, this->drivers[i]->device.flags);
                     if ((this->drivers[i]->device.flags & JD_DEVICE_FLAGS_INITIALISED) && this->drivers[i]->device.address == pkt->address)
                     {
-                        if (this->drivers[i]->device.flags & JD_DEVICE_FLAGS_BROADCAST_MAP)
+                        if (this->drivers[i]->device.flags & JD_DEVICE_FLAGS_BROADCAST && this->drivers[i]->device.flags & JD_DEVICE_FLAGS_REMOTE)
                         {
                             JD_DMESG("BROADMAP DETECTED");
                             driver_class = this->drivers[i]->device.driver_class;

--- a/source/JACDAC/JDProtocol.cpp
+++ b/source/JACDAC/JDProtocol.cpp
@@ -50,8 +50,6 @@ void JDProtocol::onPacketReceived(Event)
         // address 0 will never be filtered.
         if (!logic.filterPacket(pkt->address))
         {
-            uint32_t driver_class = 0;
-
             JD_DMESG("NOT FILTERED");
             for (int i = 0; i < JD_PROTOCOL_DRIVER_ARRAY_SIZE; i++)
             {
@@ -61,32 +59,12 @@ void JDProtocol::onPacketReceived(Event)
                     JD_DMESG("DRIV a:%d sn:%d i:%d f %d", this->drivers[i]->device.address, this->drivers[i]->device.serial_number, this->drivers[i]->device.flags & JD_DEVICE_FLAGS_INITIALISED ? 1 : 0, this->drivers[i]->device.flags);
                     if ((this->drivers[i]->device.flags & JD_DEVICE_FLAGS_INITIALISED) && this->drivers[i]->device.address == pkt->address)
                     {
-                        if (this->drivers[i]->device.flags & JD_DEVICE_FLAGS_BROADCAST && this->drivers[i]->device.flags & JD_DEVICE_FLAGS_REMOTE)
-                        {
-                            JD_DMESG("BROADMAP DETECTED");
-                            driver_class = this->drivers[i]->device.driver_class;
-                        }
-                        else
-                        {
-                            // DMESG("HANDLED BY LOCAL / REMOTE A: %d", this->drivers[i]->getAddress());
-                            this->drivers[i]->handlePacket(pkt);
-                        }
-
+                        // DMESG("HANDLED BY LOCAL / REMOTE A: %d", this->drivers[i]->getAddress());
+                        this->drivers[i]->handlePacket(pkt);
                         break; // only one address per device, lets break early
                     }
                 }
             }
-
-            // if we've matched a broadcast map, it means we need to map a broadcast packet to any driver of the same class
-            if (driver_class > 0)
-                for (int i = 0; i < JD_PROTOCOL_DRIVER_ARRAY_SIZE; i++)
-                {
-                    if ((this->drivers[i]->device.flags & JD_DEVICE_FLAGS_BROADCAST) && this->drivers[i]->device.driver_class == driver_class)
-                    {
-                        JD_DMESG("HANDLED BY BROADCAST");
-                        this->drivers[i]->handlePacket(pkt);
-                    }
-                }
         }
 
         if (bridge != NULL)


### PR DESCRIPTION
The logic driver ignored disconnect / connect events for broadcast drivers. There was also a risk that by connecting and disconnecting broadcast drivers from the bus, you could crash a jacdac device.

cc @pelikhan 

Just need to test.