### PR TITLE
USB fixes for STM

### DIFF
--- a/inc/driver-models/CodalUSB.h
+++ b/inc/driver-models/CodalUSB.h
@@ -211,7 +211,6 @@ public:
 class UsbEndpointOut
 {
     uint8_t buf[USB_MAX_PKT_SIZE];
-    void startRead();
 
 public:
     volatile uint32_t userdata;
@@ -223,12 +222,14 @@ public:
     // when IRQ disabled, endpointRequest() callback will not be called (generally)
     int disableIRQ();
     int enableIRQ();
+    void startRead();
 
     UsbEndpointOut(uint8_t idx, uint8_t type, uint8_t size = USB_MAX_PKT_SIZE);
 };
 
 void usb_configure(uint8_t numEndpoints);
 void usb_set_address(uint16_t wValue);
+void usb_set_address_pre(uint16_t wValue);
 
 class CodalUSBInterface
 {

--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -451,6 +451,7 @@ void CodalUSB::setupRequest(USBSetup &setup)
             sendzlp();
             break;
         case USB_REQ_SET_ADDRESS:
+            usb_set_address_pre(wValue);
             sendzlp();
             usb_set_address(wValue);
             break;

--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -408,7 +408,7 @@ int CodalUSB::interfaceRequest(USBSetup &setup, bool isClass)
 
 void CodalUSB::setupRequest(USBSetup &setup)
 {
-    DMESG("SETUP Req=%x type=%x val=%x:%x idx=%x len=%d", setup.bRequest, setup.bmRequestType,
+    LOG("SETUP Req=%x type=%x val=%x:%x idx=%x len=%d", setup.bRequest, setup.bmRequestType,
           setup.wValueH, setup.wValueL, setup.wIndex, setup.wLength);
 
     int status = DEVICE_OK;

--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -43,7 +43,7 @@ static uint8_t usb_status = 0;
 // static uint8_t usb_suspended = 0; // copy of UDINT to check SUSPI and WAKEUPI bits
 static uint8_t usb_configured = 0;
 
-static const ConfigDescriptor static_config = {9, 2, 0, 0, 1, 0, USB_CONFIG_BUS_POWERED, 50};
+static const ConfigDescriptor static_config = {9, 2, 0, 0, 1, 0, USB_CONFIG_BUS_POWERED, 250};
 
 static const DeviceDescriptor default_device_desc = {
     0x12, // bLength
@@ -146,7 +146,7 @@ static const uint8_t msOS20Descriptor[] = {
     '{', 0, '9', 0, '2', 0, 'C', 0, 'E', 0, '6', 0, '4', 0, '6', 0, '2', 0, '-', 0, '9', 0, 'C', 0,
     '7', 0, '7', 0, '-', 0, '4', 0, '6', 0, 'F', 0, 'E', 0, '-', 0, '9', 0, '3', 0, '3', 0, 'B', 0,
     '-', 0, '3', 0, '1', 0, 'C', 0, 'B', 0, '9', 0, 'C', 0, '5', 0, 'A', 0, 'A', 0, '3', 0, 'B', 0,
-    '9', 0, '}', 0, 0, 0, 0, 0};
+    'A', 0, '}', 0, 0, 0, 0, 0};
 #endif
 
 CodalUSB::CodalUSB()


### PR DESCRIPTION
Tweak USB interfaces to fit STM32 as well as SAMD:
* endpoint startRead() is now visible
* there are two callbacks for setting device address (before and after sending response)

Also:
* bump requested power to 500mA
* tweak guid used in winUSB (to avoid clashing with micro:bit, though it's unclear it causes problems)
* allow interfaces with no endpoints (just control transfers)
