### PR TITLE
Optimize Timer::sync()

### DIFF
--- a/inc/driver-models/Timer.h
+++ b/inc/driver-models/Timer.h
@@ -53,7 +53,8 @@ namespace codal
 
     class Timer
     {
-        uint32_t sigma;
+        uint16_t sigma;
+        uint16_t delta;
         LowLevelTimer& timer;
 
         /**


### PR DESCRIPTION
This eliminates 64 bit division from sync() (cutting time in half at least), and simplifies overflow check, assuming at least 16 bit timer.