### PR TITLE
Add support for ILI9341 screen

### DIFF
--- a/inc/drivers/ILI9341.h
+++ b/inc/drivers/ILI9341.h
@@ -1,0 +1,42 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2017 Lancaster University.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef DEVICE_ILI9341_H
+#define DEVICE_ILI9341_H
+
+#include "ST7735.h"
+
+namespace codal
+{
+
+class ILI9341
+{
+public:
+    ILI9341(SPI &spi, Pin &cs, Pin &dc);
+    void init();
+};
+
+}
+
+#endif

--- a/inc/drivers/ILI9341.h
+++ b/inc/drivers/ILI9341.h
@@ -30,7 +30,7 @@ DEALINGS IN THE SOFTWARE.
 namespace codal
 {
 
-class ILI9341
+class ILI9341 : public ST7735
 {
 public:
     ILI9341(SPI &spi, Pin &cs, Pin &dc);

--- a/inc/drivers/ST7735.h
+++ b/inc/drivers/ST7735.h
@@ -50,6 +50,7 @@ protected:
     Pin &dc;
     uint8_t cmdBuf[20];
     ST7735WorkBuffer *work;
+    bool double16;
 
     void sendCmd(uint8_t *buf, int len);
     void sendCmdSeq(const uint8_t *buf);

--- a/inc/drivers/ST7735.h
+++ b/inc/drivers/ST7735.h
@@ -44,6 +44,7 @@ struct ST7735WorkBuffer;
 
 class ST7735
 {
+protected:
     SPI &spi;
     Pin &cs;
     Pin &dc;
@@ -62,7 +63,7 @@ class ST7735
 
 public:
     ST7735(SPI &spi, Pin &cs, Pin &dc);
-    void init();
+    virtual void init();
 
     /**
      * Configure screen-specific parameters.

--- a/inc/drivers/ST7735.h
+++ b/inc/drivers/ST7735.h
@@ -50,6 +50,10 @@ protected:
     Pin &dc;
     uint8_t cmdBuf[20];
     ST7735WorkBuffer *work;
+
+    // if true, every pixel will be plotted as 4 pixels and 16 bit color mode
+    // will be used; this is for ILI9341 which usually has 320x240 screens
+    // and doesn't support 12 bit color
     bool double16;
 
     void sendCmd(uint8_t *buf, int len);

--- a/source/drivers/ILI9341.cpp
+++ b/source/drivers/ILI9341.cpp
@@ -57,10 +57,62 @@
 #define ILI9341_GMCTRN1 0xE1 ///< Negative Gamma Correction
 //#define ILI9341_PWCTR6     0xFC
 
-// Parameters based on https://github.com/adafruit/Adafruit_ILI9341
 
 // clang-format off
 static const uint8_t initcmd[] = {
+
+#if 0
+    // Parameters based on https://github.com/juj/fbcp-ili9341
+    0x01/*Software Reset*/, 0x80, 5,
+    0x28/*Display OFF*/, 0,
+    // The following appear in ILI9341 Data Sheet v1.11 (2011/06/10), but not in older v1.02 (2010/12/06).
+    0xCB/*Power Control A*/, 5, 0x39/*Reserved*/, 0x2C/*Reserved*/, 0x00/*Reserved*/, 0x34/*REG_VD=1.6V*/, 0x02/*VBC=5.6V*/,
+    0xCF/*Power Control B*/, 3, 0x00/*Always Zero*/, 0xC1/*Power Control=0,DRV_ena=0,PCEQ=1*/, 0x30,/*DC_ena=1*/ // Not sure what the effect is, set to default as per ILI9341 Application Notes v0.6 (2011/03/11) document (which is not apparently same as default at power on).
+    0xE8/*Driver Timing Control A*/, 3, 0x85, 0x00, 0x78, // Not sure what the effect is, set to default as per ILI9341 Application Notes v0.6 (2011/03/11) document (which is not apparently same as default at power on).
+    0xEA/*Driver Timing Control B*/, 2, 0x00, 0x00, // Not sure what the effect is, set to default as per ILI9341 Application Notes v0.6 (2011/03/11) document (which is not apparently same as default at power on).
+    0xED/*Power On Sequence Control*/, 4, 0x64, 0x03, 0x12, 0x81, // Not sure what the effect is, set to default as per ILI9341 Application Notes v0.6 (2011/03/11) document (which is not apparently same as default at power on).
+    // The following appear also in old ILI9341 Data Sheet v1.02 (2010/12/06).
+    0xC0/*Power Control 1*/, 1, 0x23,/*VRH=4.60V*/ // Set the GVDD level, which is a reference level for the VCOM level and the grayscale voltage level.
+    0xC1/*Power Control 2*/, 1, 0x10,/*AVCC=VCIx2,VGH=VCIx7,VGL=-VCIx4*/ // Sets the factor used in the step-up circuits. To reduce power consumption, set a smaller factor.
+    0xC5/*VCOM Control 1*/, 2, 0x3e/*VCOMH=4.250V*/, 0x28,/*VCOML=-1.500V*/ // Adjusting VCOM 1 and 2 can control display brightness
+    0xC7/*VCOM Control 2*/, 1, 0x86,/*VCOMH=VMH-58,VCOML=VML-58*/
+
+    0x36/*MADCTL: Memory Access Control*/  , 1, 0x48,             // Memory Access Control
+
+    0x20/*Display Inversion OFF*/, 0,
+    0x3A/*COLMOD: Pixel Format Set*/, 1, 0x55,/*DPI=16bits/pixel,DBI=16bits/pixel*/
+
+    // According to spec sheet, display frame rate in 4-wire SPI "internal clock mode" is computed with the following formula:
+    // frameRate = 615000 / [ (pow(2,DIVA) * (320 + VFP + VBP) * RTNA ]
+    // where
+    // - DIVA is clock division ratio, 0 <= DIVA <= 3; so pow(2,DIVA) is either 1, 2, 4 or 8.
+    // - RTNA specifies the number of clocks assigned to each horizontal scanline, and must follow 16 <= RTNA <= 31.
+    // - VFP is vertical front porch, number of idle sleep scanlines before refreshing a new frame, 2 <= VFP <= 127.
+    // - VBP is vertical back porch, number of idle sleep scanlines after refreshing a new frame, 2 <= VBP <= 127.
+
+    // Max refresh rate then is with DIVA=0, VFP=2, VBP=2 and RTNA=16:
+    // maxFrameRate = 615000 / (1 * (320 + 2 + 2) * 16) = 118.63 Hz
+
+    // To get 60fps, set DIVA=0, RTNA=31, VFP=2 and VBP=2:
+    // minFrameRate = 615000 / (8 * (320 + 2 + 2) * 31) = 61.23 Hz
+
+    // It seems that in internal clock mode, horizontal front and back porch settings (HFP, BFP) are ignored(?)
+
+    0xB1/*Frame Rate Control (In Normal Mode/Full Colors)*/, 2, 0x00/*DIVA=fosc*/, 0x18,/*RTNA(Frame Rate)*/
+
+    0xB6/*Display Function Control*/, 1, 0x08,/*PTG=Interval Scan,PT=V63/V0/VCOML/VCOMH*/ 0x82/*REV=1(Normally white),ISC(Scan Cycle)=5 frames*/, 1, 0x27,/*LCD Driver Lines=320*/
+    0xF2/*Enable 3G*/, 1, 0x02,/*False*/ // This one is present only in ILI9341 Data Sheet v1.11 (2011/06/10)
+    0x26/*Gamma Set*/, 1, 0x01/*Gamma curve 1 (G2.2)*/,
+    0xE0/*Positive Gamma Correction*/, 15, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, 0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00,
+    0xE1/*Negative Gamma Correction*/, 15, 0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, 0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F,
+    0x11, 0x80, /*Sleep Out*/
+    120,
+    /*Display ON*/0x29, 0x80,
+    120,
+    0, 0,
+#else
+
+  // Parameters based on https://github.com/adafruit/Adafruit_ILI9341
   0xEF, 3, 0x03, 0x80, 0x02,
   0xCF, 3, 0x00, 0xC1, 0x30,
   0xED, 4, 0x64, 0x03, 0x12, 0x81,
@@ -87,7 +139,9 @@ static const uint8_t initcmd[] = {
     120,
   ILI9341_DISPON  , 0x80,                // Display on
     120,
-  0x00                                   // End of list
+  0x00, 0x00,                                // End of list
+#endif
+
 };
 // clang-format on
 

--- a/source/drivers/ILI9341.cpp
+++ b/source/drivers/ILI9341.cpp
@@ -1,0 +1,108 @@
+#include "ILI9341.h"
+#include "CodalFiber.h"
+#include "CodalDmesg.h"
+
+#define ILI9341_NOP        0x00     ///< No-op register
+#define ILI9341_SWRESET    0x01     ///< Software reset register
+#define ILI9341_RDDID      0x04     ///< Read display identification information
+#define ILI9341_RDDST      0x09     ///< Read Display Status
+
+#define ILI9341_SLPIN      0x10     ///< Enter Sleep Mode
+#define ILI9341_SLPOUT     0x11     ///< Sleep Out
+#define ILI9341_PTLON      0x12     ///< Partial Mode ON
+#define ILI9341_NORON      0x13     ///< Normal Display Mode ON
+
+#define ILI9341_RDMODE     0x0A     ///< Read Display Power Mode
+#define ILI9341_RDMADCTL   0x0B     ///< Read Display MADCTL
+#define ILI9341_RDPIXFMT   0x0C     ///< Read Display Pixel Format
+#define ILI9341_RDIMGFMT   0x0D     ///< Read Display Image Format
+#define ILI9341_RDSELFDIAG 0x0F     ///< Read Display Self-Diagnostic Result
+
+#define ILI9341_INVOFF     0x20     ///< Display Inversion OFF
+#define ILI9341_INVON      0x21     ///< Display Inversion ON
+#define ILI9341_GAMMASET   0x26     ///< Gamma Set
+#define ILI9341_DISPOFF    0x28     ///< Display OFF
+#define ILI9341_DISPON     0x29     ///< Display ON
+
+#define ILI9341_CASET      0x2A     ///< Column Address Set
+#define ILI9341_PASET      0x2B     ///< Page Address Set
+#define ILI9341_RAMWR      0x2C     ///< Memory Write
+#define ILI9341_RAMRD      0x2E     ///< Memory Read
+
+#define ILI9341_PTLAR      0x30     ///< Partial Area
+#define ILI9341_MADCTL     0x36     ///< Memory Access Control
+#define ILI9341_VSCRSADD   0x37     ///< Vertical Scrolling Start Address
+#define ILI9341_PIXFMT     0x3A     ///< COLMOD: Pixel Format Set
+
+#define ILI9341_FRMCTR1    0xB1     ///< Frame Rate Control (In Normal Mode/Full Colors)
+#define ILI9341_FRMCTR2    0xB2     ///< Frame Rate Control (In Idle Mode/8 colors)
+#define ILI9341_FRMCTR3    0xB3     ///< Frame Rate control (In Partial Mode/Full Colors)
+#define ILI9341_INVCTR     0xB4     ///< Display Inversion Control
+#define ILI9341_DFUNCTR    0xB6     ///< Display Function Control
+
+#define ILI9341_PWCTR1     0xC0     ///< Power Control 1
+#define ILI9341_PWCTR2     0xC1     ///< Power Control 2
+#define ILI9341_PWCTR3     0xC2     ///< Power Control 3
+#define ILI9341_PWCTR4     0xC3     ///< Power Control 4
+#define ILI9341_PWCTR5     0xC4     ///< Power Control 5
+#define ILI9341_VMCTR1     0xC5     ///< VCOM Control 1
+#define ILI9341_VMCTR2     0xC7     ///< VCOM Control 2
+
+#define ILI9341_RDID1      0xDA     ///< Read ID 1
+#define ILI9341_RDID2      0xDB     ///< Read ID 2
+#define ILI9341_RDID3      0xDC     ///< Read ID 3
+#define ILI9341_RDID4      0xDD     ///< Read ID 4
+
+#define ILI9341_GMCTRP1    0xE0     ///< Positive Gamma Correction
+#define ILI9341_GMCTRN1    0xE1     ///< Negative Gamma Correction
+//#define ILI9341_PWCTR6     0xFC
+
+// Parameters based on https://github.com/adafruit/Adafruit_ILI9341
+
+// clang-format off
+static const uint8_t initcmd[] = {
+  0xEF, 3, 0x03, 0x80, 0x02,
+  0xCF, 3, 0x00, 0xC1, 0x30,
+  0xED, 4, 0x64, 0x03, 0x12, 0x81,
+  0xE8, 3, 0x85, 0x00, 0x78,
+  0xCB, 5, 0x39, 0x2C, 0x00, 0x34, 0x02,
+  0xF7, 1, 0x20,
+  0xEA, 2, 0x00, 0x00,
+  ILI9341_PWCTR1  , 1, 0x23,             // Power control VRH[5:0]
+  ILI9341_PWCTR2  , 1, 0x10,             // Power control SAP[2:0];BT[3:0]
+  ILI9341_VMCTR1  , 2, 0x3e, 0x28,       // VCM control
+  ILI9341_VMCTR2  , 1, 0x86,             // VCM control2
+  ILI9341_MADCTL  , 1, 0x48,             // Memory Access Control
+  ILI9341_VSCRSADD, 1, 0x00,             // Vertical scroll zero
+  ILI9341_PIXFMT  , 1, 0x55,
+  ILI9341_FRMCTR1 , 2, 0x00, 0x18,
+  ILI9341_DFUNCTR , 3, 0x08, 0x82, 0x27, // Display Function Control
+  0xF2, 1, 0x00,                         // 3Gamma Function Disable
+  ILI9341_GAMMASET , 1, 0x01,             // Gamma curve selected
+  ILI9341_GMCTRP1 , 15, 0x0F, 0x31, 0x2B, 0x0C, 0x0E, 0x08, // Set Gamma
+    0x4E, 0xF1, 0x37, 0x07, 0x10, 0x03, 0x0E, 0x09, 0x00,
+  ILI9341_GMCTRN1 , 15, 0x00, 0x0E, 0x14, 0x03, 0x11, 0x07, // Set Gamma
+    0x31, 0xC1, 0x48, 0x08, 0x0F, 0x0C, 0x31, 0x36, 0x0F,
+  ILI9341_SLPOUT  , 0x80,                // Exit Sleep
+    120,
+  ILI9341_DISPON  , 0x80,                // Display on
+    120,
+  0x00                                   // End of list
+};
+// clang-format on
+
+namespace codal
+{
+
+ILI9341::ILI9341(SPI &spi, Pin &cs, Pin &dc) : spi(spi), cs(cs), dc(dc), work(NULL) {}
+
+void ILI9341::init()
+{
+    cs.setDigitalValue(1);
+    dc.setDigitalValue(1);
+
+    fiber_sleep(10);
+    sendCmdSeq(initcmd);
+}
+
+} // namespace codal

--- a/source/drivers/ILI9341.cpp
+++ b/source/drivers/ILI9341.cpp
@@ -2,59 +2,59 @@
 #include "CodalFiber.h"
 #include "CodalDmesg.h"
 
-#define ILI9341_NOP        0x00     ///< No-op register
-#define ILI9341_SWRESET    0x01     ///< Software reset register
-#define ILI9341_RDDID      0x04     ///< Read display identification information
-#define ILI9341_RDDST      0x09     ///< Read Display Status
+#define ILI9341_NOP 0x00     ///< No-op register
+#define ILI9341_SWRESET 0x01 ///< Software reset register
+#define ILI9341_RDDID 0x04   ///< Read display identification information
+#define ILI9341_RDDST 0x09   ///< Read Display Status
 
-#define ILI9341_SLPIN      0x10     ///< Enter Sleep Mode
-#define ILI9341_SLPOUT     0x11     ///< Sleep Out
-#define ILI9341_PTLON      0x12     ///< Partial Mode ON
-#define ILI9341_NORON      0x13     ///< Normal Display Mode ON
+#define ILI9341_SLPIN 0x10  ///< Enter Sleep Mode
+#define ILI9341_SLPOUT 0x11 ///< Sleep Out
+#define ILI9341_PTLON 0x12  ///< Partial Mode ON
+#define ILI9341_NORON 0x13  ///< Normal Display Mode ON
 
-#define ILI9341_RDMODE     0x0A     ///< Read Display Power Mode
-#define ILI9341_RDMADCTL   0x0B     ///< Read Display MADCTL
-#define ILI9341_RDPIXFMT   0x0C     ///< Read Display Pixel Format
-#define ILI9341_RDIMGFMT   0x0D     ///< Read Display Image Format
-#define ILI9341_RDSELFDIAG 0x0F     ///< Read Display Self-Diagnostic Result
+#define ILI9341_RDMODE 0x0A     ///< Read Display Power Mode
+#define ILI9341_RDMADCTL 0x0B   ///< Read Display MADCTL
+#define ILI9341_RDPIXFMT 0x0C   ///< Read Display Pixel Format
+#define ILI9341_RDIMGFMT 0x0D   ///< Read Display Image Format
+#define ILI9341_RDSELFDIAG 0x0F ///< Read Display Self-Diagnostic Result
 
-#define ILI9341_INVOFF     0x20     ///< Display Inversion OFF
-#define ILI9341_INVON      0x21     ///< Display Inversion ON
-#define ILI9341_GAMMASET   0x26     ///< Gamma Set
-#define ILI9341_DISPOFF    0x28     ///< Display OFF
-#define ILI9341_DISPON     0x29     ///< Display ON
+#define ILI9341_INVOFF 0x20   ///< Display Inversion OFF
+#define ILI9341_INVON 0x21    ///< Display Inversion ON
+#define ILI9341_GAMMASET 0x26 ///< Gamma Set
+#define ILI9341_DISPOFF 0x28  ///< Display OFF
+#define ILI9341_DISPON 0x29   ///< Display ON
 
-#define ILI9341_CASET      0x2A     ///< Column Address Set
-#define ILI9341_PASET      0x2B     ///< Page Address Set
-#define ILI9341_RAMWR      0x2C     ///< Memory Write
-#define ILI9341_RAMRD      0x2E     ///< Memory Read
+#define ILI9341_CASET 0x2A ///< Column Address Set
+#define ILI9341_PASET 0x2B ///< Page Address Set
+#define ILI9341_RAMWR 0x2C ///< Memory Write
+#define ILI9341_RAMRD 0x2E ///< Memory Read
 
-#define ILI9341_PTLAR      0x30     ///< Partial Area
-#define ILI9341_MADCTL     0x36     ///< Memory Access Control
-#define ILI9341_VSCRSADD   0x37     ///< Vertical Scrolling Start Address
-#define ILI9341_PIXFMT     0x3A     ///< COLMOD: Pixel Format Set
+#define ILI9341_PTLAR 0x30    ///< Partial Area
+#define ILI9341_MADCTL 0x36   ///< Memory Access Control
+#define ILI9341_VSCRSADD 0x37 ///< Vertical Scrolling Start Address
+#define ILI9341_PIXFMT 0x3A   ///< COLMOD: Pixel Format Set
 
-#define ILI9341_FRMCTR1    0xB1     ///< Frame Rate Control (In Normal Mode/Full Colors)
-#define ILI9341_FRMCTR2    0xB2     ///< Frame Rate Control (In Idle Mode/8 colors)
-#define ILI9341_FRMCTR3    0xB3     ///< Frame Rate control (In Partial Mode/Full Colors)
-#define ILI9341_INVCTR     0xB4     ///< Display Inversion Control
-#define ILI9341_DFUNCTR    0xB6     ///< Display Function Control
+#define ILI9341_FRMCTR1 0xB1 ///< Frame Rate Control (In Normal Mode/Full Colors)
+#define ILI9341_FRMCTR2 0xB2 ///< Frame Rate Control (In Idle Mode/8 colors)
+#define ILI9341_FRMCTR3 0xB3 ///< Frame Rate control (In Partial Mode/Full Colors)
+#define ILI9341_INVCTR 0xB4  ///< Display Inversion Control
+#define ILI9341_DFUNCTR 0xB6 ///< Display Function Control
 
-#define ILI9341_PWCTR1     0xC0     ///< Power Control 1
-#define ILI9341_PWCTR2     0xC1     ///< Power Control 2
-#define ILI9341_PWCTR3     0xC2     ///< Power Control 3
-#define ILI9341_PWCTR4     0xC3     ///< Power Control 4
-#define ILI9341_PWCTR5     0xC4     ///< Power Control 5
-#define ILI9341_VMCTR1     0xC5     ///< VCOM Control 1
-#define ILI9341_VMCTR2     0xC7     ///< VCOM Control 2
+#define ILI9341_PWCTR1 0xC0 ///< Power Control 1
+#define ILI9341_PWCTR2 0xC1 ///< Power Control 2
+#define ILI9341_PWCTR3 0xC2 ///< Power Control 3
+#define ILI9341_PWCTR4 0xC3 ///< Power Control 4
+#define ILI9341_PWCTR5 0xC4 ///< Power Control 5
+#define ILI9341_VMCTR1 0xC5 ///< VCOM Control 1
+#define ILI9341_VMCTR2 0xC7 ///< VCOM Control 2
 
-#define ILI9341_RDID1      0xDA     ///< Read ID 1
-#define ILI9341_RDID2      0xDB     ///< Read ID 2
-#define ILI9341_RDID3      0xDC     ///< Read ID 3
-#define ILI9341_RDID4      0xDD     ///< Read ID 4
+#define ILI9341_RDID1 0xDA ///< Read ID 1
+#define ILI9341_RDID2 0xDB ///< Read ID 2
+#define ILI9341_RDID3 0xDC ///< Read ID 3
+#define ILI9341_RDID4 0xDD ///< Read ID 4
 
-#define ILI9341_GMCTRP1    0xE0     ///< Positive Gamma Correction
-#define ILI9341_GMCTRN1    0xE1     ///< Negative Gamma Correction
+#define ILI9341_GMCTRP1 0xE0 ///< Positive Gamma Correction
+#define ILI9341_GMCTRN1 0xE1 ///< Negative Gamma Correction
 //#define ILI9341_PWCTR6     0xFC
 
 // Parameters based on https://github.com/adafruit/Adafruit_ILI9341
@@ -94,7 +94,10 @@ static const uint8_t initcmd[] = {
 namespace codal
 {
 
-ILI9341::ILI9341(SPI &spi, Pin &cs, Pin &dc) : spi(spi), cs(cs), dc(dc), work(NULL) {}
+ILI9341::ILI9341(SPI &spi, Pin &cs, Pin &dc) : ST7735(spi, cs, dc)
+{
+    double16 = true;
+}
 
 void ILI9341::init()
 {

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -65,7 +65,9 @@
 namespace codal
 {
 
-ST7735::ST7735(SPI &spi, Pin &cs, Pin &dc) : spi(spi), cs(cs), dc(dc), work(NULL) {}
+ST7735::ST7735(SPI &spi, Pin &cs, Pin &dc) : spi(spi), cs(cs), dc(dc), work(NULL) {
+    double16 = false;
+}
 
 #define DELAY 0x80
 
@@ -146,7 +148,7 @@ void ST7735::sendBytes(unsigned num)
 
     if (double16)
     {
-        uint32_t *dst = work->dataBuf;
+        uint32_t *dst = (uint32_t *)work->dataBuf;
         while (num--)
         {
             uint8_t v = *work->srcPtr++;
@@ -183,7 +185,7 @@ void ST7735::sendWords(unsigned numBytes)
     if (double16)
         while (numWords--)
         {
-            uint32_t s = *src++;
+            uint32_t v = *src++;
             *dst++ = 0x08210821 * (0xf & (v >> 0));
             *dst++ = 0x08210821 * (0xf & (v >> 4));
             *dst++ = 0x08210821 * (0xf & (v >> 8));
@@ -237,10 +239,10 @@ void ST7735::sendColorsStep(ST7735 *st)
         work->x++;
     }
 
-    if (double16 && work->srcLeft == 0 && work->x++ < (work->width << 1))
+    if (st->double16 && work->srcLeft == 0 && work->x++ < (work->width << 1))
     {
-        work->srcLeft = (height + 1) >> 1;
-        if ((x & 1) == 0)
+        work->srcLeft = (work->height + 1) >> 1;
+        if ((work->x & 1) == 0)
         {
             work->srcPtr -= work->srcLeft;
         }
@@ -266,7 +268,7 @@ void ST7735::sendColorsStep(ST7735 *st)
     }
     else
     {
-        if (double16)
+        if (st->double16)
             st->sendWords(sizeof(work->dataBuf) / 8);
         else
             st->sendWords((sizeof(work->dataBuf) / (3 * 4)) * 4);

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -143,15 +143,30 @@ void ST7735::sendBytes(unsigned num)
     if (num > work->srcLeft)
         num = work->srcLeft;
     work->srcLeft -= num;
-    uint8_t *dst = work->dataBuf;
-    while (num--)
+
+    if (double16)
     {
-        uint32_t v = work->expPalette[*work->srcPtr++];
-        *dst++ = v;
-        *dst++ = v >> 8;
-        *dst++ = v >> 16;
+        uint32_t *dst = work->dataBuf;
+        while (num--)
+        {
+            uint8_t v = *work->srcPtr++;
+            *dst++ = 0x08210821 * (v & 0xf);
+            *dst++ = 0x08210821 * (v >> 4);
+        }
+        startTransfer((uint8_t *)dst - work->dataBuf);
     }
-    startTransfer(dst - work->dataBuf);
+    else
+    {
+        uint8_t *dst = work->dataBuf;
+        while (num--)
+        {
+            uint32_t v = work->expPalette[*work->srcPtr++];
+            *dst++ = v;
+            *dst++ = v >> 8;
+            *dst++ = v >> 16;
+        }
+        startTransfer(dst - work->dataBuf);
+    }
 }
 
 void ST7735::sendWords(unsigned numBytes)
@@ -165,17 +180,31 @@ void ST7735::sendWords(unsigned numBytes)
     uint32_t *tbl = work->expPalette;
     uint32_t *dst = (uint32_t *)work->dataBuf;
 
-    while (numWords--)
-    {
-        uint32_t s = *src++;
-        uint32_t o = tbl[s & 0xff];
-        uint32_t v = tbl[(s >> 8) & 0xff];
-        *dst++ = o | (v << 24);
-        o = tbl[(s >> 16) & 0xff];
-        *dst++ = (v >> 8) | (o << 16);
-        v = tbl[s >> 24];
-        *dst++ = (o >> 16) | (v << 8);
-    }
+    if (double16)
+        while (numWords--)
+        {
+            uint32_t s = *src++;
+            *dst++ = 0x08210821 * (0xf & (v >> 0));
+            *dst++ = 0x08210821 * (0xf & (v >> 4));
+            *dst++ = 0x08210821 * (0xf & (v >> 8));
+            *dst++ = 0x08210821 * (0xf & (v >> 12));
+            *dst++ = 0x08210821 * (0xf & (v >> 16));
+            *dst++ = 0x08210821 * (0xf & (v >> 20));
+            *dst++ = 0x08210821 * (0xf & (v >> 24));
+            *dst++ = 0x08210821 * (0xf & (v >> 28));
+        }
+    else
+        while (numWords--)
+        {
+            uint32_t s = *src++;
+            uint32_t o = tbl[s & 0xff];
+            uint32_t v = tbl[(s >> 8) & 0xff];
+            *dst++ = o | (v << 24);
+            o = tbl[(s >> 16) & 0xff];
+            *dst++ = (v >> 8) | (o << 16);
+            v = tbl[s >> 24];
+            *dst++ = (o >> 16) | (v << 8);
+        }
 
     work->srcPtr = (uint8_t *)src;
     startTransfer((uint8_t *)dst - work->dataBuf);
@@ -185,7 +214,8 @@ void ST7735::sendColorsStep(ST7735 *st)
 {
     ST7735WorkBuffer *work = st->work;
 
-    if (work->paletteTable) {
+    if (work->paletteTable)
+    {
         auto palette = work->paletteTable;
         work->paletteTable = NULL;
         memset(work->dataBuf, 0, sizeof(work->dataBuf));
@@ -205,6 +235,15 @@ void ST7735::sendColorsStep(ST7735 *st)
     {
         st->startRAMWR();
         work->x++;
+    }
+
+    if (double16 && work->srcLeft == 0 && work->x++ < (work->width << 1))
+    {
+        work->srcLeft = (height + 1) >> 1;
+        if ((x & 1) == 0)
+        {
+            work->srcPtr -= work->srcLeft;
+        }
     }
 
     // with the current image format in PXT the sendBytes cases never happen
@@ -227,7 +266,10 @@ void ST7735::sendColorsStep(ST7735 *st)
     }
     else
     {
-        st->sendWords((sizeof(work->dataBuf) / (3 * 4)) * 4);
+        if (double16)
+            st->sendWords(sizeof(work->dataBuf) / 8);
+        else
+            st->sendWords((sizeof(work->dataBuf) / (3 * 4)) * 4);
     }
 }
 
@@ -267,8 +309,9 @@ int ST7735::sendIndexedImage(const uint8_t *src, unsigned width, unsigned height
     {
         work = new ST7735WorkBuffer;
         memset(work, 0, sizeof(*work));
-        for (int i = 0; i < 256; ++i)
-            work->expPalette[i] = 0x1011 * (i & 0xf) | (0x110100 * (i>>4));
+        if (!double16)
+            for (int i = 0; i < 256; ++i)
+                work->expPalette[i] = 0x1011 * (i & 0xf) | (0x110100 * (i >> 4));
         EventModel::defaultEventBus->listen(DEVICE_ID_DISPLAY, 100, this, &ST7735::sendDone);
     }
 
@@ -281,7 +324,10 @@ int ST7735::sendIndexedImage(const uint8_t *src, unsigned width, unsigned height
     work->srcPtr = src;
     work->width = width;
     work->height = height;
-    work->srcLeft = ((width + 1) >> 1) * height;
+    work->srcLeft = (height + 1) >> 1;
+    // when not scaling up, we don't care about where lines end
+    if (!double16)
+        work->srcLeft *= width;
     work->x = 0;
 
     sendColorsStep(this);
@@ -327,8 +373,10 @@ void ST7735::sendCmdSeq(const uint8_t *buf)
 
 void ST7735::setAddrWindow(int x, int y, int w, int h)
 {
-    uint8_t cmd0[] = {ST7735_RASET, 0, (uint8_t)x, 0, (uint8_t)(x + w - 1)};
-    uint8_t cmd1[] = {ST7735_CASET, 0, (uint8_t)y, 0, (uint8_t)(y + h - 1)};
+    int x2 = x + w - 1;
+    int y2 = y + h - 1;
+    uint8_t cmd0[] = {ST7735_RASET, (uint8_t)(x >> 8), (uint8_t)x, (uint8_t)(x2 >> 8), (uint8_t)x2};
+    uint8_t cmd1[] = {ST7735_CASET, (uint8_t)(y >> 8), (uint8_t)y, (uint8_t)(y2 >> 8), (uint8_t)y2};
     sendCmd(cmd1, sizeof(cmd1));
     sendCmd(cmd0, sizeof(cmd0));
 }
@@ -342,11 +390,13 @@ void ST7735::init()
     sendCmdSeq(initCmds);
 }
 
-void ST7735::configure(uint8_t madctl, uint32_t frmctr1) {
+void ST7735::configure(uint8_t madctl, uint32_t frmctr1)
+{
     uint8_t cmd0[] = {ST7735_MADCTL, madctl};
-    uint8_t cmd1[] = {ST7735_FRMCTR1, (uint8_t)(frmctr1 >> 16), (uint8_t)(frmctr1 >> 8), (uint8_t)frmctr1};
+    uint8_t cmd1[] = {ST7735_FRMCTR1, (uint8_t)(frmctr1 >> 16), (uint8_t)(frmctr1 >> 8),
+                      (uint8_t)frmctr1};
     sendCmd(cmd0, sizeof(cmd0));
     sendCmd(cmd1, cmd1[3] == 0xff ? 3 : 4);
 }
 
-}
+} // namespace codal


### PR DESCRIPTION
The screen is very similar to st7735, except for:
* init sequence
* no support for 12 bit color; we use 16 bit
* the driver currently assumes we want 2x scaled images, which keeps the resolution similar to ST7735