### PR TITLE
Set defualt USB current to 100mA and allow for changes

### DIFF
--- a/inc/driver-models/CodalUSB.h
+++ b/inc/driver-models/CodalUSB.h
@@ -277,6 +277,7 @@ public:
 
     // initialized by constructor, can be overriden before start()
     uint8_t numStringDescriptors;
+    uint8_t maxPower;
     const char **stringDescriptors;
     const DeviceDescriptor *deviceDescriptor;
 

--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -43,7 +43,7 @@ static uint8_t usb_status = 0;
 // static uint8_t usb_suspended = 0; // copy of UDINT to check SUSPI and WAKEUPI bits
 static uint8_t usb_configured = 0;
 
-static const ConfigDescriptor static_config = {9, 2, 0, 0, 1, 0, USB_CONFIG_BUS_POWERED, 250};
+static const ConfigDescriptor static_config = {9, 2, 0, 0, 1, 0, USB_CONFIG_BUS_POWERED, 0};
 
 static const DeviceDescriptor default_device_desc = {
     0x12, // bLength
@@ -186,6 +186,7 @@ CodalUSB::CodalUSB()
     startDelayCount = 1;
     interfaces = NULL;
     numWebUSBInterfaces = 0;
+    maxPower = 50; // 100mA; if set to 500mA can't connect to iOS devices
 }
 
 void CodalUSBInterface::fillInterfaceInfo(InterfaceDescriptor *descp)
@@ -225,6 +226,7 @@ int CodalUSB::sendConfig()
     memcpy(buf, &static_config, sizeof(ConfigDescriptor));
     ((ConfigDescriptor *)buf)->clen = clen;
     ((ConfigDescriptor *)buf)->numInterfaces = numInterfaces;
+    ((ConfigDescriptor *)buf)->maxPower = maxPower;
     clen = sizeof(ConfigDescriptor);
 
 #define ADD_DESC(desc)                                                                             \


### PR DESCRIPTION
This was originally set here: https://github.com/lancaster-university/codal-core/pull/32
I broke it later: https://github.com/lancaster-university/codal-core/commit/36dafe77219239c1397ece44ed37a7f6e6f50d5a

I guess the problem is that CPX can indeed draw more than 100mA, but I guess we'll just take the chances. Making it configurable, but PXT will keep the new 100mA default.

Original issue: https://github.com/microsoft/pxt-adafruit/issues/837
Current issue: https://forum.makecode.com/t/circuit-playground-express-on-mobile-devices/799
