### PR TITLE
Fix bug for using ILI9341(320x240)

### DIFF
--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -367,7 +367,10 @@ int ST7735::sendIndexedImage(const uint8_t *src, unsigned width, unsigned height
     work->srcPtr = src;
     work->width = width;
     work->height = height;
-    work->srcLeft = (height + 1) >> 1;
+    if (!double16)
+        work->srcLeft = (height + 1) >> 1;
+    else
+        work->srcLeft = (height + 1) >> 2;
     // when not scaling up, we don't care about where lines end
     if (!double16)
         work->srcLeft *= width;

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -249,7 +249,7 @@ void ST7735::sendColorsStep(ST7735 *st)
         work->x++;
     }
 
-    if (st->double16 && work->srcLeft == 0 && work->x++ < (work->width << 1))
+    if (st->double16 && work->srcLeft == 0 && work->x++ < (work->width))
     {
         work->srcLeft = (work->height + 1) >> 1;
         if ((work->x & 1) == 0)

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -251,7 +251,7 @@ void ST7735::sendColorsStep(ST7735 *st)
 
     if (st->double16 && work->srcLeft == 0 && work->x++ < (work->width))
     {
-        work->srcLeft = (work->height + 1) >> 1;
+        work->srcLeft = (work->height + 1) >> 2;
         if ((work->x & 1) == 0)
         {
             work->srcPtr -= work->srcLeft;


### PR DESCRIPTION
1. Current algorithm for writing to ILI9341(320x240) LCD is using it as 160x120 resolution, i.e., each 2x2 pixel has the same color.
Therefore, the first line with downgraded resolution has 240 x 2 = 480 pixels, but from the view point of information, they actually express 120 x 1 = 120 independent pixels. 
Also, current algorithm uses 4-bit(0.5 byte) color palette. So 120 pixels actually need 60 bytes.
Therefore, for transmitting each line(virtually one line and actually two lines), we need 60 bytes (the initial value of **work->srcLeft**) image data.
2. Current algorithm transfers [the image data for one line] twice(if ((work->x & 1) == 0) in sendcolorsStep() is that part), which is for downgrading resolution. Therefore, we actually need to transfer 320 times(the maximum value of **work->x**).
3. When using ILI9341(320x240), the total size of image data should be 60 x 160 = 9600bytes. Because 60bytes for each line and there are actually 160 lines in 160x120 resolution.

* The commit message of commit b12343c should be "in case of 320x240 lcd, transfer **_320 times rather than 640 times_**"