### PR TITLE
Add target_hash_serial_number()

### DIFF
--- a/inc/core/codal_target_hal.h
+++ b/inc/core/codal_target_hal.h
@@ -44,6 +44,12 @@ extern "C"
     int target_random(int max);
 
     uint64_t target_get_serial();
+  
+    /**
+     * Compute 64-bit hash of manufacturer provided serial number.
+     * Can be used by target_get_serial().
+     */
+    uint64_t target_hash_serial_number(uint32_t *serialdata, unsigned numwords);
 
     void target_wait_for_event();
   

--- a/source/core/codal_default_target_hal.cpp
+++ b/source/core/codal_default_target_hal.cpp
@@ -38,3 +38,42 @@ __attribute__((weak)) void target_deepsleep()
     // if not implemented, default to WFI
     target_wait_for_event();
 }
+
+static uint32_t murmur_hash2_core(uint32_t *d, int words)
+{
+    const uint32_t m = 0x5bd1e995;
+    uint32_t h = 0;
+
+    while (words--)
+    {
+        uint32_t k = *d++;
+        k *= m;
+        k ^= k >> 24;
+        k *= m;
+        h *= m;
+        h ^= k;
+    }
+
+    return h;
+}
+
+// https://en.wikipedia.org/wiki/Fowler%E2%80%93Noll%E2%80%93Vo_hash_function
+static uint32_t hash_fnv1a(const void *data, unsigned len)
+{
+    const uint8_t *d = (const uint8_t *)data;
+    uint32_t h = 0x811c9dc5;
+    while (len--)
+        h = (h ^ *d++) * 0x1000193;
+    return h;
+}
+
+/**
+ * Compute 64-bit hash of manufacturer provided serial number.
+ */
+__attribute__((weak)) uint64_t target_hash_serial_number(uint32_t *serialdata, unsigned numwords)
+{
+    uint32_t w1 = hash_fnv1a(serialdata, numwords << 2);
+    uint32_t w0 = murmur_hash2_core((uint32_t *)serialdata, numwords);
+    w0 &= ~0x02000000; // clear "universal" bit
+    return ((uint64_t)w0 << 32 | w1);
+}


### PR DESCRIPTION
It is to be used by target_get_serial().

It uses FNV-1a for lower half of the serial and murmur2 for the upper half. That should give reasonably good distribution.

Example on SAMD21 (yes, words of serial are not all adjacent).

```c
uint64_t target_get_serial()
{
    static uint64_t cache;
    if (!cache)
    {
        uint32_t serial[4];
        serial[0] = *(uint32_t *)0x0080A00C;
        memcpy(serial + 1, (void *)0x0080A040, 3 * 4);
        cache = target_hash_serial_number(serial, 4);
    }
    return cache;
}
```

(the current version on D21, D51 is broken, hashing on STM32 is questionable; NRF52 has 64 bit serial, but I would be inclined to hash it anyway)
