### PR TITLE
support for LIS3DH without INT1 pin connected

### DIFF
--- a/inc/drivers/LIS3DH.h
+++ b/inc/drivers/LIS3DH.h
@@ -84,7 +84,7 @@ namespace codal
     /**
      * Class definition for Accelerometer.
      *
-     * Represents an implementation of the Freescale MMA8653 3 axis accelerometer
+     * Represents an implementation of the ST LIS3DH 3 axis accelerometer
      * Also includes basic data caching and on demand activation.
      */
     class LIS3DH : public Accelerometer
@@ -92,6 +92,7 @@ namespace codal
         I2C&            i2c;                // The I2C interface to use.
         Pin             &int1;              // Data ready interrupt.
         uint16_t        address;            // I2C address of this accelerometer.
+        uint32_t        lastUpdate;
 
         public:
 

--- a/source/drivers/LIS3DH.cpp
+++ b/source/drivers/LIS3DH.cpp
@@ -238,9 +238,11 @@ int LIS3DH::requestUpdate()
   */
 void LIS3DH::idleCallback()
 {
-    if (!&int1) {
+    if (!&int1)
+    {
         uint32_t now = codal::system_timer_current_time();
-        if (!lastUpdate || now - lastUpdate > this->samplePeriod) {
+        if (!lastUpdate || now - lastUpdate > this->samplePeriod)
+        {
             status &= ~UPDATE_DONE;
             lastUpdate = now;
         }

--- a/source/drivers/LIS3DH.cpp
+++ b/source/drivers/LIS3DH.cpp
@@ -33,6 +33,7 @@ DEALINGS IN THE SOFTWARE.
 #include "ErrorNo.h"
 #include "CodalCompat.h"
 #include "CodalFiber.h"
+#include "Timer.h"
 
 using namespace codal;
 
@@ -237,7 +238,14 @@ int LIS3DH::requestUpdate()
   */
 void LIS3DH::idleCallback()
 {
-    status &= ~HAD_IDLE;
+    static uint32_t lastTime;
+    if (!&int1) {
+        uint32_t now = codal::system_timer_current_time();
+        if (!lastTime || now-lastTime>20) {
+            status &= ~HAD_IDLE;
+            lastTime = now;
+        }
+    }
     requestUpdate();
 }
 

--- a/source/drivers/LIS3DH.cpp
+++ b/source/drivers/LIS3DH.cpp
@@ -25,7 +25,7 @@ DEALINGS IN THE SOFTWARE.
 /**
  * Class definition for an LIS3DH 3 axis accelerometer.
  *
- * Represents an implementation of the Freescale LIS3DH 3 axis accelerometer
+ * Represents an implementation of the ST LIS3DH 3 axis accelerometer
  * Also includes basic data caching and on demand activation.
  */
 #include "CodalConfig.h"

--- a/source/drivers/LIS3DH.cpp
+++ b/source/drivers/LIS3DH.cpp
@@ -158,6 +158,8 @@ int LIS3DH::whoAmI()
     return (int)data;
 }
 
+#define HAD_IDLE 0x0040
+
 /**
   * Reads the acceleration data from the accelerometer, and stores it in our buffer.
   * This only happens if the accelerometer indicates that it has new data via int1.
@@ -177,11 +179,14 @@ int LIS3DH::requestUpdate()
     status |= DEVICE_COMPONENT_STATUS_IDLE_TICK;
 
     // Poll interrupt line from accelerometer.
-    if(int1.getDigitalValue() == 1)
+    if((&int1 && int1.getDigitalValue() == 1) ||
+        (status & HAD_IDLE) == 0)
     {
         int8_t data[6];
         uint8_t src;
         int result;
+
+        status |= HAD_IDLE;
 
         // read the XYZ data (16 bit)
         // n.b. we need to set the MSB bit to enable multibyte transfers from this device (WHY? Who Knows!)
@@ -232,6 +237,7 @@ int LIS3DH::requestUpdate()
   */
 void LIS3DH::idleCallback()
 {
+    status &= ~HAD_IDLE;
     requestUpdate();
 }
 


### PR DESCRIPTION
This may not be the prettiest, but we have one prototype device that we absolutely need to support, and it doesn't have the INT pin connected.

I don't think we want to support it too much though - it's much better if folks just connect that pin (which will happen on next rev of the said device, but we need to support this one for a while).