### PR TITLE
Fixed typo: availiable -> available

### DIFF
--- a/inc/core/CodalHeapAllocator.h
+++ b/inc/core/CodalHeapAllocator.h
@@ -42,7 +42,7 @@ DEALINGS IN THE SOFTWARE.
   * what these are, and consider the tradeoffs against simplicity...
   *
   * @note The need for this should be reviewed in the future, if a different memory allocator is
-  * made availiable in the mbed platform.
+  * made available in the mbed platform.
   *
   * TODO: Consider caching recently freed blocks to improve allocation time.
   */

--- a/inc/streams/DataStream.h
+++ b/inc/streams/DataStream.h
@@ -137,14 +137,14 @@ namespace codal
         /**
          * Define a downstream component for data stream.
          *
-         * @sink The component that data will be delivered to, when it is availiable
+         * @sink The component that data will be delivered to, when it is available
          */
         virtual void connect(DataSink &sink) override;
 
         /**
          * Define a downstream component for data stream.
          *
-         * @sink The component that data will be delivered to, when it is availiable
+         * @sink The component that data will be delivered to, when it is available
          */
         virtual void disconnect() override;
 

--- a/inc/streams/Mixer.h
+++ b/inc/streams/Mixer.h
@@ -75,7 +75,7 @@ public:
     /**
      * Define a downstream component for data stream.
      *
-     * @sink The component that data will be delivered to, when it is availiable
+     * @sink The component that data will be delivered to, when it is available
      */
     virtual void connect(DataSink &sink);
 };

--- a/inc/types/ManagedString.h
+++ b/inc/types/ManagedString.h
@@ -50,7 +50,7 @@ namespace codal
       * such as Touch Develop.
       *
       * Written from first principles here, for several reasons:
-      * 1) std::shared_ptr is not yet availiable on the ARMCC compiler
+      * 1) std::shared_ptr is not yet available on the ARMCC compiler
       *
       * 2) to reduce memory footprint - we don't need many of the other features in the std library
       *

--- a/source/core/CodalFiber.cpp
+++ b/source/core/CodalFiber.cpp
@@ -154,7 +154,7 @@ Fiber * codal::get_fiber_list()
 }
 
 /**
-  * Allocates a fiber from the fiber pool if availiable. Otherwise, allocates a new one from the heap.
+  * Allocates a fiber from the fiber pool if available. Otherwise, allocates a new one from the heap.
   */
 Fiber *getFiberContext()
 {
@@ -355,7 +355,7 @@ static Fiber* handle_fob()
     // it's time to spawn a new fiber...
     if (f->flags & DEVICE_FIBER_FLAG_FOB)
     {
-        // Allocate a TCB from the new fiber. This will come from the tread pool if availiable,
+        // Allocate a TCB from the new fiber. This will come from the tread pool if available,
         // else a new one will be allocated on the heap.
 
         if (!forkedFiber)
@@ -662,7 +662,7 @@ Fiber *__create_fiber(uint32_t ep, uint32_t cp, uint32_t pm, int parameterised)
     if (ep == 0 || cp == 0)
         return NULL;
 
-    // Allocate a TCB from the new fiber. This will come from the fiber pool if availiable,
+    // Allocate a TCB from the new fiber. This will come from the fiber pool if available,
     // else a new one will be allocated on the heap.
     Fiber *newFiber = getFiberContext();
 

--- a/source/core/CodalHeapAllocator.cpp
+++ b/source/core/CodalHeapAllocator.cpp
@@ -42,7 +42,7 @@ DEALINGS IN THE SOFTWARE.
   * what these are, and consider the tradeoffs against simplicity...
   *
   * @note The need for this should be reviewed in the future, if a different memory allocator is
-  * made availiable in the mbed platform.
+  * made available in the mbed platform.
   *
   * TODO: Consider caching recently freed blocks to improve allocation time.
   */

--- a/source/streams/DataStream.cpp
+++ b/source/streams/DataStream.cpp
@@ -158,7 +158,7 @@ bool DataStream::isReadOnly()
 /**
  * Define a downstream component for data stream.
  *
- * @sink The component that data will be delivered to, when it is availiable
+ * @sink The component that data will be delivered to, when it is available
  */
 void DataStream::connect(DataSink &sink)
 {
@@ -177,7 +177,7 @@ int DataStream::getFormat()
 /**
  * Define a downstream component for data stream.
  *
- * @sink The component that data will be delivered to, when it is availiable
+ * @sink The component that data will be delivered to, when it is available
  */
 void DataStream::disconnect()
 {

--- a/source/types/ManagedString.cpp
+++ b/source/types/ManagedString.cpp
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.
   * such as Touch Develop.
   *
   * Written from first principles here, for several reasons:
-  * 1) std::shared_ptr is not yet availiable on the ARMCC compiler
+  * 1) std::shared_ptr is not yet available on the ARMCC compiler
   *
   * 2) to reduce memory footprint - we don't need many of the other features in the std library
   *


### PR DESCRIPTION
This pull-request converts the misspelling `availiable` to the correct `available`.