### PR TITLE
Input Pipeline

### DIFF
--- a/inc/core/CodalComponent.h
+++ b/inc/core/CodalComponent.h
@@ -67,6 +67,7 @@ DEALINGS IN THE SOFTWARE.
 #define DEVICE_ID_JACDAC_CONFIGURATION_SERVICE 33
 #define DEVICE_ID_SYSTEM_ADC          34
 #define DEVICE_ID_PULSE_IN            35
+#define DEVICE_ID_SPLITTER            36
 
 #define DEVICE_ID_IO_P0               100                       // IDs 100-227 are reserved for I/O Pin IDs.
 

--- a/inc/streams/LevelDetector.h
+++ b/inc/streams/LevelDetector.h
@@ -70,8 +70,9 @@ namespace codal{
           * @param highThreshold the HIGH threshold at which a LEVEL_THRESHOLD_HIGH event will be generated
           * @param lowThreshold the HIGH threshold at which a LEVEL_THRESHOLD_LOW event will be generated
           * @param id The id to use for the message bus when transmitting events.
+          * @param connectImmediately Should this component connect to upstream splitter when started
           */
-        LevelDetector(DataSource &source, int highThreshold, int lowThreshold, uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR);
+        LevelDetector(DataSource &source, int highThreshold, int lowThreshold, uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR, bool connectImmediately  = true);
 
         /**
          * Callback provided when data is ready.

--- a/inc/streams/LevelDetector.h
+++ b/inc/streams/LevelDetector.h
@@ -60,6 +60,7 @@ namespace codal{
         int             windowPosition;     // The number of samples used so far in the calculation of a window.
         int             level;              // The current, instantaneous level.
         int             sigma;              // Running total of the samples in the current window.
+        bool            activated;          // Has this component been connected yet.
 
 
         /**

--- a/inc/streams/LevelDetectorSPL.h
+++ b/inc/streams/LevelDetectorSPL.h
@@ -54,7 +54,8 @@ namespace codal{
         int             sigma;              // Running total of the samples in the current window.
         float           gain;
         float           minValue;
-
+        bool            activated;          // Has this component been connected yet.
+        bool            preProcess;         // If true, preprocess incoming data on pull request
 
         /**
           * Creates a component capable of measuring and thresholding stream data
@@ -66,7 +67,7 @@ namespace codal{
           */
         LevelDetectorSPL(DataSource &source, float highThreshold, float lowThreshold, float gain,
             float minValue = 52,
-            uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR_SPL);
+            uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR_SPL,bool preProcess = true);
 
         /**
          * Callback provided when data is ready.

--- a/inc/streams/LevelDetectorSPL.h
+++ b/inc/streams/LevelDetectorSPL.h
@@ -64,10 +64,13 @@ namespace codal{
           * @param highThreshold the HIGH threshold at which a SPL_LEVEL_THRESHOLD_HIGH event will be generated
           * @param lowThreshold the HIGH threshold at which a SPL_LEVEL_THRESHOLD_LOW event will be generated
           * @param id The id to use for the message bus when transmitting events.
+          * @param connectImmediately Should this component connect to upstream splitter when started
           */
         LevelDetectorSPL(DataSource &source, float highThreshold, float lowThreshold, float gain,
             float minValue = 52,
-            uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR_SPL,bool preProcess = true);
+            uint16_t id = DEVICE_ID_SYSTEM_LEVEL_DETECTOR_SPL,
+            bool preProcess = true,
+            bool connectImmediately  = true);
 
         /**
          * Callback provided when data is ready.

--- a/inc/streams/StreamSplitter.h
+++ b/inc/streams/StreamSplitter.h
@@ -1,0 +1,104 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2021 Lancaster University.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#include "CodalConfig.h"
+#include "DataStream.h"
+
+#ifndef STREAM_SPLITTER_H
+#define STREAM_SPLITTER_H
+
+#ifndef CONFIG_MAX_CHANNELS
+#define CONFIG_MAX_CHANNELS 10
+#endif
+
+#ifndef CONFIG_BLOCKING_THRESHOLD
+#define CONFIG_BLOCKING_THRESHOLD 100
+#endif
+
+/**
+  * Splitter events
+  */
+#define SPLITTER_ACTIVATE_CHANNEL    1
+#define SPLITTER_DEACTIVATE_CHANNEL  2
+
+
+/**
+ * Default configuration values
+ */
+
+namespace codal{
+
+    class StreamSplitter : public DataSink, public DataSource, public CodalComponent 
+    {
+
+    public:    
+        int                 numberChannels;                    // Current Number of channels Splitter is serving
+        int                 processed;                         // How many downstream components have responded to pull request
+        int                 numberAttempts;                    // Number of failed pull request attempts
+        DataSource          &upstream;                         // The upstream component of this Splitter
+        DataSink            *outputChannels[CONFIG_MAX_CHANNELS];     // Array of Datasinks the Splitter is serving
+        ManagedBuffer       lastBuffer;                        // Buffer being processed
+
+        /**
+          * Creates a component that distributes a single upstream datasource to many downstream datasinks
+          *
+          * @param source a DataSource to receive data from
+          */
+        StreamSplitter(DataSource &source, uint16_t id = DEVICE_ID_SPLITTER);
+
+        /**
+         * Callback provided when data is ready.
+         */
+        virtual int pullRequest();
+
+        /**
+         * Provide the next available ManagedBuffer to our downstream caller, if available.
+         */
+        virtual ManagedBuffer pull();
+
+        /**
+         * Register a downstream connection with splitter
+         */
+        virtual void connect(DataSink &downstream);
+
+        /**
+         *  Determine the data format of the buffers streamed out of this component.
+         */
+        virtual int getFormat();
+
+        /**
+         * Defines the data format of the buffers streamed out of this component.
+         * @param format the format to use, one of
+         */
+        virtual int setFormat(int format);
+
+        /**
+         * Destructor.
+         */
+        ~StreamSplitter();
+
+    };
+}
+
+#endif

--- a/source/streams/LevelDetector.cpp
+++ b/source/streams/LevelDetector.cpp
@@ -41,9 +41,7 @@ LevelDetector::LevelDetector(DataSource &source, int highThreshold, int lowThres
     this->lowThreshold = lowThreshold;
     this->highThreshold = highThreshold;
     this->status |= LEVEL_DETECTOR_INITIALISED;
-
-    // Register with our upstream component
-    source.connect(*this);
+    this->activated = false;
 }
 
 /**
@@ -95,9 +93,13 @@ int LevelDetector::pullRequest()
  */
 int LevelDetector::getValue()
 {
+    if(!activated){
+        // Register with our upstream component: on demand activated
+        upstream.connect(*this);
+        activated = true;
+    }
     return level;
 }
-
 
 /**
  * Set threshold to the given value. Events will be generated when these thresholds are crossed.

--- a/source/streams/LevelDetector.cpp
+++ b/source/streams/LevelDetector.cpp
@@ -31,7 +31,7 @@ DEALINGS IN THE SOFTWARE.
 
 using namespace codal;
 
-LevelDetector::LevelDetector(DataSource &source, int highThreshold, int lowThreshold, uint16_t id) : upstream(source)
+LevelDetector::LevelDetector(DataSource &source, int highThreshold, int lowThreshold, uint16_t id, bool connectImmediately) : upstream(source)
 {
     this->id = id;
     this->level = 0;
@@ -42,6 +42,10 @@ LevelDetector::LevelDetector(DataSource &source, int highThreshold, int lowThres
     this->highThreshold = highThreshold;
     this->status |= LEVEL_DETECTOR_INITIALISED;
     this->activated = false;
+    if(connectImmediately){
+        upstream.connect(*this);
+        activated = true;
+    }
 }
 
 /**

--- a/source/streams/LevelDetectorSPL.cpp
+++ b/source/streams/LevelDetectorSPL.cpp
@@ -32,7 +32,7 @@ DEALINGS IN THE SOFTWARE.
 
 using namespace codal;
 
-LevelDetectorSPL::LevelDetectorSPL(DataSource &source, float highThreshold, float lowThreshold, float gain, float minValue, uint16_t id, bool preProcess) : upstream(source)
+LevelDetectorSPL::LevelDetectorSPL(DataSource &source, float highThreshold, float lowThreshold, float gain, float minValue, uint16_t id, bool preProcess, bool connectImmediately) : upstream(source)
 {
     this->id = id;
     this->level = 0;
@@ -43,6 +43,10 @@ LevelDetectorSPL::LevelDetectorSPL(DataSource &source, float highThreshold, floa
     this->status |= LEVEL_DETECTOR_SPL_INITIALISED;
     this->activated = false;
     this->preProcess = preProcess;
+    if(connectImmediately){
+        upstream.connect(*this);
+        activated = true;
+    }
 }
 
 /**

--- a/source/streams/LevelDetectorSPL.cpp
+++ b/source/streams/LevelDetectorSPL.cpp
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #include "LevelDetector.h"
 #include "LevelDetectorSPL.h"
 #include "ErrorNo.h"
+#include "CodalDmesg.h"
 
 using namespace codal;
 
@@ -41,12 +42,13 @@ LevelDetectorSPL::LevelDetectorSPL(DataSource &source, float highThreshold, floa
     this->highThreshold = highThreshold;
     this->gain = gain;
     this->status |= LEVEL_DETECTOR_SPL_INITIALISED;
-    this->activated = false;
     this->preProcess = preProcess;
     if(connectImmediately){
         upstream.connect(*this);
-        activated = true;
+        this->activated = true;
     }
+    else
+    	this->activated = false;
 }
 
 /**

--- a/source/streams/StreamSplitter.cpp
+++ b/source/streams/StreamSplitter.cpp
@@ -1,0 +1,161 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2021 Lancaster University.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#include "CodalConfig.h"
+#include "StreamSplitter.h"
+#include "ErrorNo.h"
+#include "CodalDmesg.h"
+#include "Event.h"
+
+using namespace codal;
+
+
+/**
+ * Creates a component that distributes a single upstream datasource to many downstream datasinks
+ *
+ * @param source a DataSource to receive data from
+ */
+StreamSplitter::StreamSplitter(DataSource &source, uint16_t id) : upstream(source)//, output(*this)
+{
+
+    this->id = id;
+    this->processed = 0;
+    this->numberChannels = 0;
+    this->numberAttempts = 0;
+    // init array to NULL.
+    for (int i = 0; i < CONFIG_MAX_CHANNELS; i++)
+    {
+        outputChannels[i] = NULL;
+    } 
+    
+    source.connect(*this);
+}
+
+/**
+ * Callback provided when data is ready.
+ */
+int StreamSplitter::pullRequest()
+{
+    if (processed == numberChannels)
+    {
+        processed = 0;
+        lastBuffer = upstream.pull();
+
+        // For each downstream channel that exists in array outputChannels - make a pullRequest
+        for (int i = 0; i < CONFIG_MAX_CHANNELS; i++)
+        {
+            if (outputChannels[i] != NULL){
+                outputChannels[i]->pullRequest();
+            }
+        } 
+    }
+    else
+    {
+        numberAttempts++;
+        // If BLOCKING_THREASHOLD number of pull requests have been made whilst waiting for a
+        // downstream component to respond with a pull - assume death, remove channel and continue.
+        if(numberAttempts > CONFIG_BLOCKING_THRESHOLD){   
+            numberChannels--;
+            numberAttempts = 0;
+            if(numberChannels < 1){
+                Event e(id, SPLITTER_DEACTIVATE_CHANNEL);
+            }
+        }
+    }
+    return DEVICE_OK;
+}
+
+/**
+ * Provide the next available ManagedBuffer to our downstream caller, if available.
+ */
+ManagedBuffer StreamSplitter::pull()
+{
+    processed++;
+    return lastBuffer;
+}
+
+/**
+ * Called by downstream components to register this splitter as its dataSource.
+ */
+void StreamSplitter::connect(DataSink &downstream)
+{
+    int placed = 0;
+    DMESG("%s %p","Adding New Channel, ", &downstream);
+
+    for (int i = 0; i < CONFIG_MAX_CHANNELS; i++)
+    {
+        // Add downstream as one of the splitters datasinks that will be served
+        if (outputChannels[i] == NULL){
+            outputChannels[i] = &downstream;
+            placed = 1;
+            DMESG("%s %d","Channel Added at location ", i);
+            break;
+        }
+        else{
+            DMESG("Channel Filled, Trying Next one");
+        }
+    }
+    if(placed == 1){
+        numberChannels++;
+        processed++;
+        
+            for (int i = 0; i < CONFIG_MAX_CHANNELS; i++)
+            {
+                DMESG("%p", outputChannels[i]);
+                DMESG("%s", "-------");
+            }
+    }
+    else{
+        DMESG("Channel Not Added - Max Number of Channels Reached?");
+    }
+
+    if(numberChannels > 0){
+        //Activate ADC
+        Event e(id, SPLITTER_ACTIVATE_CHANNEL);
+    }
+}
+
+/**
+ *  Determine the data format of the buffers streamed out of this component.
+ */
+int StreamSplitter::getFormat()
+{
+    return upstream.getFormat();
+}
+
+/**
+ * Defines the data format of the buffers streamed out of this component.
+ * @param format the format to use
+ */
+int StreamSplitter::setFormat(int format)
+{
+    return DEVICE_NOT_SUPPORTED;
+}
+
+/**
+ * Destructor.
+ */
+StreamSplitter::~StreamSplitter()
+{
+}

--- a/source/streams/StreamSplitter.cpp
+++ b/source/streams/StreamSplitter.cpp
@@ -36,7 +36,7 @@ using namespace codal;
  *
  * @param source a DataSource to receive data from
  */
-StreamSplitter::StreamSplitter(DataSource &source, uint16_t id) : upstream(source)//, output(*this)
+StreamSplitter::StreamSplitter(DataSource &source, uint16_t id) : upstream(source)
 {
 
     this->id = id;


### PR DESCRIPTION
Ready for review or merge into new branch

Introduced 'stream splitter' which takes the mic input after coming through the processor and distributes it to many downstream consumers. This allows other downstream code to connect to the mic input easily, modualr way without having to the up the pipeline themselves.

Additionally level detector and level detector SPL now have an initilised instance in uBit and so can be accessed globally in user code - special parameters have been added to their constructors so that they can be inisilised but dont start up untill they are needed to prevent the mic starting up when uBit starts.

Matches pull requests on codal-microbit-v2 and codal nrf-52 with the same name