### PR TITLE
Remove `using namespace` directive in a header

### DIFF
--- a/inc/driver-models/Pin.h
+++ b/inc/driver-models/Pin.h
@@ -57,7 +57,6 @@ DEALINGS IN THE SOFTWARE.
 
 namespace codal
 {
-    using namespace codal;
     /**
       * Pin capabilities enum.
       * Used to determine the capabilities of each Pin as some can only be digital, or can be both digital and analogue.


### PR DESCRIPTION
A `using namespace` inside a header makes useless namespace so it should be removed.