### PR TITLE
Ensure AnimatedDisplay::waitForFreeDisplay() is free of race conditions

### DIFF
--- a/source/drivers/AnimatedDisplay.cpp
+++ b/source/drivers/AnimatedDisplay.cpp
@@ -274,7 +274,7 @@ void AnimatedDisplay::stopAnimation()
 void AnimatedDisplay::waitForFreeDisplay()
 {
     // If there's an ongoing animation, wait for our turn to display.
-    if (animationMode != ANIMATION_MODE_NONE && animationMode != ANIMATION_MODE_STOPPED)
+    while (animationMode != ANIMATION_MODE_NONE && animationMode != ANIMATION_MODE_STOPPED)
         fiber_wait_for_event(DEVICE_ID_NOTIFY, DISPLAY_EVT_FREE);
 }
 


### PR DESCRIPTION
Update to the internal  AnimatedDisplay::waitForFreeDisplay() method to ensure that fibers queued waiting for access to the display always re-contest for access, thereby avoiding potential race conditions.