### PR TITLE
Add REAL_TIME_FUNC attribute

### DIFF
--- a/inc/core/codal_target_hal.h
+++ b/inc/core/codal_target_hal.h
@@ -94,5 +94,14 @@ extern "C"
 
 }
 
+// This is re-defined in targets with external flash, that require certain functions to be placed in RAM
+#ifndef REAL_TIME_FUNC
+#define REAL_TIME_FUNC /* */
+#endif
+
+// This is for cycle-precise wait even in presence of flash caches (forces function to sit in RAM)
+#ifndef FORCE_RAM_FUNC
+#define FORCE_RAM_FUNC __attribute__((noinline, long_call, section(".data")))
+#endif
 
 #endif

--- a/inc/driver-models/Timer.h
+++ b/inc/driver-models/Timer.h
@@ -342,7 +342,7 @@ namespace codal
      *
      * @note the amount of cycles per iteration will vary between CPUs.
      */
-    __attribute__((noinline, long_call, section(".data")))
+    FORCE_RAM_FUNC
     void system_timer_wait_cycles(uint32_t cycles);
 
     /**

--- a/source/core/CodalDmesg.cpp
+++ b/source/core/CodalDmesg.cpp
@@ -44,7 +44,7 @@ static void logwriten(const char *msg, int l)
     {
         *(uint32_t *)codalLogStore.buffer = 0x0a2e2e2e; // "...\n"
         codalLogStore.ptr = 4;
-        if (l >= sizeof(codalLogStore.buffer) - 5)
+        if (l >= (int)sizeof(codalLogStore.buffer) - 5)
         {
             msg = "DMESG line too long!\n";
             l = 21;

--- a/source/core/CodalFiber.cpp
+++ b/source/core/CodalFiber.cpp
@@ -82,6 +82,7 @@ using namespace codal;
   *
   * @param queue The run queue to add the fiber to.
   */
+REAL_TIME_FUNC
 void codal::queue_fiber(Fiber *f, Fiber **queue)
 {
     target_disable_irq();
@@ -119,6 +120,7 @@ void codal::queue_fiber(Fiber *f, Fiber **queue)
   *
   * @param f the fiber to remove.
   */
+REAL_TIME_FUNC
 void codal::dequeue_fiber(Fiber *f)
 {
     // If this fiber is already dequeued, nothing the there's nothing to do.
@@ -156,6 +158,7 @@ Fiber * codal::get_fiber_list()
 /**
   * Allocates a fiber from the fiber pool if available. Otherwise, allocates a new one from the heap.
   */
+REAL_TIME_FUNC
 Fiber *getFiberContext()
 {
     Fiber *f;
@@ -737,6 +740,7 @@ void codal::release_fiber(void *)
   *
   * Any fiber reaching the end of its entry function will return here  for recycling.
   */
+REAL_TIME_FUNC
 void codal::release_fiber(void)
 {
     if (!fiber_scheduler_running())
@@ -1045,6 +1049,7 @@ FiberLock::FiberLock()
 /**
  * Block the calling fiber until the lock is available
  **/
+REAL_TIME_FUNC
 void FiberLock::wait()
 {
     // If the scheduler is not running, then simply exit, as we're running monothreaded.

--- a/source/core/CodalHeapAllocator.cpp
+++ b/source/core/CodalHeapAllocator.cpp
@@ -191,6 +191,7 @@ uint32_t device_heap_size(uint8_t heap_index)
   *
   * @return A pointer to the allocated memory, or NULL if insufficient memory is available.
   */
+REAL_TIME_FUNC
 void *device_malloc_in(size_t size, HeapDefinition &heap)
 {
     PROCESSOR_WORD_TYPE	blockSize = 0;
@@ -281,6 +282,7 @@ void *device_malloc_in(size_t size, HeapDefinition &heap)
   *
   * @return A pointer to the allocated memory, or NULL if insufficient memory is available.
   */
+REAL_TIME_FUNC
 void* device_malloc (size_t size)
 {
     static uint8_t initialised = 0;
@@ -340,6 +342,7 @@ void* device_malloc (size_t size)
   *
   * @param mem The memory area to release.
   */
+REAL_TIME_FUNC
 void device_free (void *mem)
 {
     PROCESSOR_WORD_TYPE	*memory = (PROCESSOR_WORD_TYPE *)mem;

--- a/source/core/codal_default_target_hal.cpp
+++ b/source/core/codal_default_target_hal.cpp
@@ -8,6 +8,7 @@ __attribute__((weak)) void target_wait(uint32_t milliseconds)
     codal::system_timer_wait_ms(milliseconds);
 }
 
+REAL_TIME_FUNC
 __attribute__((weak)) void target_wait_us(uint32_t us)
 {
     codal::system_timer_wait_us(us);

--- a/source/driver-models/Timer.cpp
+++ b/source/driver-models/Timer.cpp
@@ -62,6 +62,7 @@ void timer_callback(uint16_t chan)
     }
 }
 
+REAL_TIME_FUNC
 void Timer::triggerIn(CODAL_TIMESTAMP t)
 {
     if (t < CODAL_TIMER_MINIMUM_PERIOD) t = CODAL_TIMER_MINIMUM_PERIOD;
@@ -141,6 +142,7 @@ CODAL_TIMESTAMP Timer::getTime()
  *
  * @return the timestamp in microseconds
  */
+REAL_TIME_FUNC
 CODAL_TIMESTAMP Timer::getTimeUs()
 {
     sync();
@@ -159,6 +161,7 @@ int Timer::enableInterrupts()
     return DEVICE_OK;
 }
 
+REAL_TIME_FUNC
 int Timer::setEvent(CODAL_TIMESTAMP period, uint16_t id, uint16_t value, bool repeat, uint32_t flags)
 {
     TimerEvent *evt = getTimerEvent();
@@ -188,6 +191,7 @@ int Timer::setEvent(CODAL_TIMESTAMP period, uint16_t id, uint16_t value, bool re
  *
  * @param value the value that was given upon a previous call to eventEvery / eventAfter
  */
+REAL_TIME_FUNC
 int Timer::cancel(uint16_t id, uint16_t value)
 {
     int res = DEVICE_INVALID_PARAMETER;
@@ -286,6 +290,7 @@ int Timer::eventEveryUs(CODAL_TIMESTAMP period, uint16_t id, uint16_t value, uin
  * Callback from physical timer implementation code.
  * @param t Indication that t time units (typically microsends) have elapsed.
  */
+REAL_TIME_FUNC
 void Timer::sync()
 {
     // Need to disable all IRQs - for example if SPI IRQ is triggered during
@@ -430,6 +435,7 @@ TimerEvent *Timer::deepSleepWakeUpEvent()
   *
   * @return the current time since power on in microseconds
   */
+REAL_TIME_FUNC
 CODAL_TIMESTAMP Timer::deepSleepBegin( CODAL_TIMESTAMP &counter)
 {
     // Need to disable all IRQs - for example if SPI IRQ is triggered during
@@ -484,6 +490,7 @@ CODAL_TIMESTAMP Timer::deepSleepBegin( CODAL_TIMESTAMP &counter)
   *
   * @return DEVICE_OK or DEVICE_NOT_SUPPORTED if no timer has been registered.
   */
+REAL_TIME_FUNC
 void Timer::deepSleepEnd( CODAL_TIMESTAMP counter, CODAL_TIMESTAMP micros)
 {
     // On entry, the timer IRQ is disabled and must not be enabled
@@ -725,6 +732,7 @@ int codal::system_timer_calibrate_cycles()
  * @param cycles the number of nops to execute
  * @return DEVICE_OK
  */
+FORCE_RAM_FUNC
 void codal::system_timer_wait_cycles(uint32_t cycles)
 {
     __asm__ __volatile__(
@@ -748,6 +756,7 @@ void codal::system_timer_wait_cycles(uint32_t cycles)
  * @note this provides a good starting point for non-timing critical applications. For more accurate timings,
  * please use a cycle-based wait approach (see system_timer_wait_cycles)
  */
+REAL_TIME_FUNC
 int codal::system_timer_wait_us(uint32_t period)
 {
     if(system_timer == NULL)
@@ -772,6 +781,7 @@ int codal::system_timer_wait_us(uint32_t period)
  * @note this provides a good starting point for non-timing critical applications. For more accurate timings,
  * please use a cycle-based wait approach (see system_timer_wait_cycles)
  */
+REAL_TIME_FUNC
 int codal::system_timer_wait_ms(uint32_t period)
 {
     return system_timer_wait_us(period * 1000);

--- a/source/drivers/HIDKeyboard.cpp
+++ b/source/drivers/HIDKeyboard.cpp
@@ -203,8 +203,8 @@ int USBHIDKeyboard::updateReport(HIDKeyboardReport* report)
     if(report == NULL)
         return DEVICE_INVALID_PARAMETER;
 
-	if (!in)
-		return DEVICE_INVALID_STATE;
+    if (!in)
+        return DEVICE_INVALID_STATE;
 
     uint8_t reportBuf[report->reportSize + 1] = {report->reportID};
     memcpy(reportBuf + 1, report->keyState, report->reportSize);

--- a/source/drivers/LEDMatrix.cpp
+++ b/source/drivers/LEDMatrix.cpp
@@ -151,8 +151,11 @@ void LEDMatrix::render()
     matrixMap.rowPins[strobeRow]->setDigitalValue(1);
 
     //timer does not have enough resolution for brightness of 1. 23.53 us
+    #pragma GCC diagnostic push
+    #pragma GCC diagnostic ignored "-Wtype-limits"
     if(brightness <= LED_MATRIX_MAXIMUM_BRIGHTNESS && brightness > LED_MATRIX_MINIMUM_BRIGHTNESS)
         system_timer_event_after_us(frameTimeout, id, LED_MATRIX_EVT_FRAME_TIMEOUT);
+    #pragma GCC diagnostic pop
 
     //this will take around 23us to execute
     if(brightness <= LED_MATRIX_MINIMUM_BRIGHTNESS)

--- a/source/drivers/MessageBus.cpp
+++ b/source/drivers/MessageBus.cpp
@@ -153,6 +153,7 @@ void async_callback(void *param)
   *
   * @param The event to queue.
   */
+REAL_TIME_FUNC
 void MessageBus::queueEvent(Event &evt)
 {
     int processingComplete;
@@ -205,6 +206,7 @@ void MessageBus::queueEvent(Event &evt)
   *
   * @return a pointer to the EventQueueItem that is at the head of the list.
   */
+REAL_TIME_FUNC
 EventQueueItem* MessageBus::dequeueEvent()
 {
     EventQueueItem *item = NULL;


### PR DESCRIPTION
This is needed by RP2040 - the flash is external any function calls into flash typically involve 20us+ latency (which increases the more code you run).

While this is quite ugly, the real ugly bit is in codal-rp2040 where I had to copy a bunch of SDK functions since they do not have these attributes... 
