### PR TITLE
Fix for problems compiling on gcc 10.3.x+

### DIFF
--- a/inc/core/codal_target_hal.h
+++ b/inc/core/codal_target_hal.h
@@ -101,7 +101,7 @@ extern "C"
 
 // This is for cycle-precise wait even in presence of flash caches (forces function to sit in RAM)
 #ifndef FORCE_RAM_FUNC
-#define FORCE_RAM_FUNC __attribute__((noinline, long_call, section(".data")))
+#define FORCE_RAM_FUNC __attribute__((noinline, long_call, section(".data.ramfuncs")))
 #endif
 
 #endif


### PR DESCRIPTION
FORCE_RAM_FUNC now correctly uses .data.ramfuncs rather than plain .data, to work with newer gcc versions. See issue #33 at https://github.com/lancaster-university/microbit-v2-samples/issues/33