### PR TITLE
Serial ASYNC mode documentation update and behavioural fix

### DIFF
--- a/inc/driver-models/Serial.h
+++ b/inc/driver-models/Serial.h
@@ -182,6 +182,11 @@ namespace codal
           *        gives a different behaviour:
           *
           *            ASYNC - bytes are copied into the txBuff and returns immediately.
+          *                    If there is insufficient space in txBuff, then only the first 'n'
+          *                    bytes will actually be sent, refer to the return value to get
+          *                    how many bytes were actually put in the buffer.
+          *                    To ensure all bytes are sent on an ASYNC call, set an appropriate
+          *                    buffer length beforehand using setTxBufferSize.
           *
           *            SYNC_SPINWAIT - bytes are copied into the txBuff and this method
           *                            will spin (lock up the processor) until all bytes
@@ -210,6 +215,11 @@ namespace codal
           *        gives a different behaviour:
           *
           *            ASYNC - bytes are copied into the txBuff and returns immediately.
+          *                    If there is insufficient space in txBuff, then only the first 'n'
+          *                    bytes will actually be sent, refer to the return value to get
+          *                    how many bytes were actually put in the buffer.
+          *                    To ensure all bytes are sent on an ASYNC call, set an appropriate
+          *                    buffer length beforehand using setTxBufferSize.
           *
           *            SYNC_SPINWAIT - bytes are copied into the txBuff and this method
           *                            will spin (lock up the processor) until all bytes

--- a/source/driver-models/Serial.cpp
+++ b/source/driver-models/Serial.cpp
@@ -97,7 +97,8 @@ int Serial::setTxInterrupt(uint8_t *string, int len, SerialMode mode)
                 while(txBufferedSize() > 0);
 
             if(mode == ASYNC)
-                fiber_sleep(0); // Deschedule ourselves until there's room to continue copying!
+                return copiedBytes; // Explicitly return less than the full string. We can't 'immediately return' if we have to wait for more buffer space.
+                                    // Note that for applications that need to guarantee this works every time, they should set the buffer length before calling send().
         }
 
         this->txBuff[txBuffHead] = string[copiedBytes];


### PR DESCRIPTION
Updated the serial send() ASYNC mode to correctly follow the spec in the documentation. Updated the documentation with further information on the behaviour.

See https://github.com/lancaster-university/codal-microbit-v2/issues/149 for a deeper discussion on this.