### PR TITLE
Enforced serial RX pullup on a redirect, to match micro:bit v1.xx behaviour

### DIFF
--- a/source/driver-models/Serial.cpp
+++ b/source/driver-models/Serial.cpp
@@ -846,6 +846,9 @@ int Serial::redirect(Pin& tx, Pin& rx)
 
     disableInterrupt(RxInterrupt);
 
+    // To be compatible with V1 behaviour
+    rx.setPull( PullMode::Up );
+
     configurePins(tx, rx);
 
     enableInterrupt(RxInterrupt);


### PR DESCRIPTION
In line with the discussion in the `codal-microbit-v2` issue here: https://github.com/lancaster-university/codal-microbit-v2/issues/179