### PR TITLE
Removed and repurposed DEVICE_USB_ERROR

### DIFF
--- a/inc/core/ErrorNo.h
+++ b/inc/core/ErrorNo.h
@@ -91,8 +91,9 @@ enum PanicCode{
     // Dereference of a NULL pointer through the ManagedType class,
     DEVICE_NULL_DEREFERENCE = 40,
 
-    // Non-recoverable error in USB driver
-    DEVICE_USB_ERROR = 50,
+    // All ob-board peripheral failures should report from the 50-59 range, but may be device specific
+    // DO NOT USE ANYTHING BETWEEN 50 AND 60 HERE - used by implementing boards/libraries
+    DEVICE_PERIPHERAL_ERROR = 50,
 
     // Non-recoverable error in the JACDAC stack
     DEVICE_JACDAC_ERROR = 60,


### PR DESCRIPTION
Removed as its never used, and repurposed it for the base error address DEVICE_PERIPHERAL_ERROR, from which on-board periperhal errors can be numbered, as required, for implementing boards.

The Micro:bit v2, for example now has a `MicroBitPanic` enum with `ACCELEROMETER_ERROR = PanicCode::DEVICE_PERIPHERAL_ERROR + 1, // Aka. Panic 51` available for device specific peripheral errors.

Note: the entire 50->59 space is available for board-specific errors.

See also:
- https://github.com/lancaster-university/codal-microbit-v2/issues/213
- https://github.com/lancaster-university/codal-microbit-v2/issues/191