### PR TITLE
Feature/enhanced lock

### DIFF
--- a/source/core/CodalFiber.cpp
+++ b/source/core/CodalFiber.cpp
@@ -813,7 +813,7 @@ void codal::fiber_scheduler_set_deepsleep_pending( int pending)
 FiberLock::FiberLock( int initial )
 {
     queue = NULL;
-    locked = 1-initial;
+    locked = 0-initial;
 }
 
 FiberLock::FiberLock() : FiberLock( 0 ) {}


### PR DESCRIPTION
Fixes an off-by-one error in the default initialisation of FiberLock objects.

Closes #152 