### PR TITLE
DEVICE_USB_ERROR -> DEVICE_PERIPHERAL_ERROR

### DIFF
--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -679,7 +679,7 @@ int CodalUSB::start()
 void usb_panic(int lineNumber)
 {
     DMESG("USB assertion failed: line %d", lineNumber);
-    target_panic(DEVICE_USB_ERROR);
+    target_panic(DEVICE_PERIPHERAL_ERROR);
 }
 
 #endif

--- a/source/drivers/GhostFAT.cpp
+++ b/source/drivers/GhostFAT.cpp
@@ -396,7 +396,7 @@ GFATEntry *GhostFAT::addFile(GFATReadCallback read, void *userdata, const char *
                              uint32_t size, uint8_t dirid)
 {
     if (filesFinalized())
-        target_panic(DEVICE_USB_ERROR);
+        target_panic(DEVICE_PERIPHERAL_ERROR);
 
     GFATEntry *f = (GFATEntry *)malloc(sizeof(GFATEntry) + strlen(filename) + 1);
     memset(f, 0, sizeof(GFATEntry));


### PR DESCRIPTION
Updates usages of DEVICE_USB_ERROR to DEVICE_PERIPHERAL_ERROR.

DEVICE_PERIPHERAL_ERROR was introduced in PR https://github.com/lancaster-university/codal-core/pull/151 and DEVICE_USB_ERROR is no longer defined. 