### PR TITLE
Dynamic pin peripherals

### DIFF
--- a/inc/core/CodalComponent.h
+++ b/inc/core/CodalComponent.h
@@ -71,6 +71,16 @@ DEALINGS IN THE SOFTWARE.
 #define DEVICE_ID_SPLITTER            37
 #define DEVICE_ID_AUDIO_PROCESSOR     38
 #define DEVICE_ID_TAP                 39
+#define DEVICE_ID_POWER_MANAGER       40
+
+// Slightly dubious IDs, moved here for now to remove conflicts
+#define DEVICE_ID_PARTIAL_FLASHING    41
+#define DEVICE_ID_USB_FLASH_MANAGER   42
+#define DEVICE_ID_VIRTUAL_SPEAKER_PIN 43
+#define DEVICE_ID_LOG                 44
+
+// Suggested range for device-specific IDs: 50-79
+// NOTE - not final, just suggested currently.
 
 #define DEVICE_ID_IO_P0               100                       // IDs 100-227 are reserved for I/O Pin IDs.
 

--- a/inc/driver-models/I2C.h
+++ b/inc/driver-models/I2C.h
@@ -37,7 +37,7 @@ namespace codal
 
 enum AcknowledgeType {ACK, NACK};
 
-class I2C
+class I2C : public PinPeripheral
 {
 public:
     I2C(Pin &sda, Pin &scl);
@@ -80,6 +80,15 @@ protected:
     virtual int read(AcknowledgeType ack = ACK);
 
 public:
+    /**
+      * Change the pins used by this I2C peripheral to those provided.
+      *
+      * @param sda the Pin to use for the I2C SDA line.
+      * @param scl the Pin to use for the I2C SCL line.
+      * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+      */
+    virtual int redirect(Pin &sda, Pin &scl);
+      
     /**
       * Issues a standard, 2 byte I2C command write to the I2C bus.
       * This consists of:

--- a/inc/driver-models/I2C.h
+++ b/inc/driver-models/I2C.h
@@ -88,7 +88,7 @@ public:
       * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
       */
     virtual int redirect(Pin &sda, Pin &scl);
-      
+
     /**
       * Issues a standard, 2 byte I2C command write to the I2C bus.
       * This consists of:

--- a/inc/driver-models/Pin.h
+++ b/inc/driver-models/Pin.h
@@ -27,6 +27,7 @@ DEALINGS IN THE SOFTWARE.
 
 #include "CodalConfig.h"
 #include "CodalComponent.h"
+#include "PinPeripheral.h"
                                                           // Status Field flags...
 #define IO_STATUS_DIGITAL_IN                0x0001        // Pin is configured as a digital input, with no pull up.
 #define IO_STATUS_DIGITAL_OUT               0x0002        // Pin is configured as a digital output
@@ -59,6 +60,7 @@ DEALINGS IN THE SOFTWARE.
 namespace codal
 {
     using namespace codal;
+
     /**
       * Pin capabilities enum.
       * Used to determine the capabilities of each Pin as some can only be digital, or can be both digital and analogue.
@@ -531,6 +533,13 @@ namespace codal
             return (status & IO_STATUS_WAKE_ON_ACTIVE) ? 1 : 0;
         }
 
+        /**
+          * Record that a given peripheral has been connected to this pin.
+          */
+        virtual void connect(PinPeripheral &p, bool deleteOnRelease = false)
+        {
+            p.deleteOnRelease = deleteOnRelease;
+        }
         /**
           * Disconnect any attached peripherals from this pin.
           */

--- a/inc/driver-models/PinPeripheral.h
+++ b/inc/driver-models/PinPeripheral.h
@@ -40,6 +40,8 @@ namespace codal
     class PinPeripheral
     {        
         public:
+        bool deleteOnRelease = false;
+        bool pinLock = false;
 
         /**
           * Method to release the given pin from a peripheral, if already bound.
@@ -49,7 +51,26 @@ namespace codal
           * @param pin the Pin to be released
           */
         virtual int releasePin(Pin &pin);
-        bool deleteOnRelease = false;
+
+        /**
+          * Determines if this peripheral has locked any attached pins to this peripheral.
+          * During a locked period, any attempts to release or reassign those pins to a differnet peripheral are ignored.
+          * This mechanism is primarily useful to use functions such as Pin::setDigitalValue() within a peripheral driver,
+          * but without releasing the pin's binding to that peripheral.
+          *
+          * @return true if this peripherals pin bindings are locked, false otherwise.
+          */
+        bool isPinLocked();
+
+        /**
+          * Controls if this peripheral has locked any attached pins to this peripheral.
+          * During a locked period, any attempts to release or reassign those pins to a differnet peripheral are ignored.
+          * This mechanism is primarily useful to use functions such as Pin::setDigitalValue() within a peripheral driver,
+          * but without releasing the pin's binding to that peripheral.
+          *
+          * @param true if this peripherals pin bindings are to be locked, false otherwise.
+          */
+        void setPinLock(bool locked);
 
         /**
          * Utility function, to assist in redirect() operations and consistent use of disconnect()/connect() by peripherals.

--- a/inc/driver-models/PinPeripheral.h
+++ b/inc/driver-models/PinPeripheral.h
@@ -1,0 +1,66 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2022 Lancaster University.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#ifndef PIN_PERIPHERAL_H
+#define PIN_PERIPHERAL_H
+
+#include "CodalConfig.h"
+#include "CodalComponent.h"
+
+namespace codal
+{
+    /**
+      * Class definition for PinPeripheral.
+      *
+      * Serves as an abstract base class for any device driver that directly interacts with a Pin.
+      * Provides the necessary function to enable safe, dynamic rebinding of pins to peripherals at runtime
+      */
+    class Pin;
+    class PinPeripheral
+    {        
+        public:
+
+        /**
+          * Method to release the given pin from a peripheral, if already bound.
+          * Device drivers should override this method to disconnect themselves from the give pin
+          * to allow it to be used by a different peripheral.
+          *
+          * @param pin the Pin to be released
+          */
+        virtual int releasePin(Pin &pin);
+        bool deleteOnRelease = false;
+
+        /**
+         * Utility function, to assist in redirect() operations and consistent use of disconnect()/connect() by peripherals.
+         * Safely disconnects pin from any attached peripherals, upfates pin to the new pin, and attaches to the given peripheral.
+         * Also validates out NULL cases.
+         *
+         * @param pin Typically a mutable instance variable, holding the current pin used by a given peripheral.
+         * @param newPin The pin which is replacing the value of pin.
+         */
+        int reassignPin(void *pin, Pin *newPin);
+    };
+}
+
+#endif

--- a/inc/driver-models/PinPeripheral.h
+++ b/inc/driver-models/PinPeripheral.h
@@ -38,7 +38,7 @@ namespace codal
       */
     class Pin;
     class PinPeripheral
-    {        
+    {
         public:
         bool deleteOnRelease = false;
         bool pinLock = false;

--- a/inc/driver-models/SPI.h
+++ b/inc/driver-models/SPI.h
@@ -39,9 +39,20 @@ typedef void (*PVoidCallback)(void *);
 /**
  * Class definition for an SPI interface.
  */
-class SPI
+class SPI : public PinPeripheral
 {
 public:
+
+    /**
+      * Change the pins used by this I2C peripheral to those provided.
+      *
+      * @param mosi the Pin to use for the SPI input line.
+      * @param miso the Pin to use for the SPI output line.
+      * @param sclk the Pin to use for the SPI clock line.
+      * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+      */
+    virtual int redirect(Pin &mosi, Pin &miso, Pin &sclk);
+
     /** Set the frequency of the SPI interface
      *
      * @param frequency The bus frequency in hertz

--- a/inc/driver-models/Serial.h
+++ b/inc/driver-models/Serial.h
@@ -65,12 +65,12 @@ namespace codal
       *
       * Represents an instance of RawSerial which accepts codal device specific data types.
       */
-    class Serial : public CodalComponent
+    class Serial : public PinPeripheral, public CodalComponent
     {
         protected:
 
-        Pin& tx;
-        Pin& rx;
+        Pin* tx;
+        Pin* rx;
 
         //delimeters used for matching on receive.
         ManagedString delimeters;

--- a/inc/driver-models/SingleWireSerial.h
+++ b/inc/driver-models/SingleWireSerial.h
@@ -22,7 +22,7 @@ namespace codal
         SingleWireDisconnected
     };
 
-    class SingleWireSerial : public CodalComponent
+    class SingleWireSerial : public PinPeripheral, public CodalComponent
     {
         protected:
         virtual void configureRxInterrupt(int enable) = 0;
@@ -39,6 +39,7 @@ namespace codal
         {
             this->id = id;
             this->cb = NULL;
+            p.connect(*this);
         }
 
         /**

--- a/inc/drivers/Button.h
+++ b/inc/drivers/Button.h
@@ -38,7 +38,7 @@ namespace codal
       *
       * Represents a single, generic button on the device.
       */
-    class Button : public AbstractButton
+    class Button : public AbstractButton, public PinPeripheral
     {
         unsigned long downStartTime;                            // used to store the current system clock when a button down event occurs
         uint8_t sigma;                                          // integration of samples over time. We use this for debouncing, and noise tolerance for touch sensing
@@ -124,6 +124,15 @@ namespace codal
         {
             return _pin.isWakeOnActive();
         }
+
+        /**
+          * Method to release the given pin from a peripheral, if already bound.
+          * Device drivers should override this method to disconnect themselves from the give pin
+          * to allow it to be used by a different peripheral.
+          *
+          * @param pin the Pin to be released
+          */
+        virtual int releasePin(Pin &pin) override;
 
         /**
           * Destructor for Button, where we deregister this instance from the array of fiber components.

--- a/inc/drivers/PulseIn.h
+++ b/inc/drivers/PulseIn.h
@@ -34,7 +34,7 @@ DEALINGS IN THE SOFTWARE.
 namespace codal
 {
 
-class PulseIn
+class PulseIn : public PinPeripheral
 {
     Pin             &pin;
     uint32_t        lastPeriod;
@@ -75,9 +75,21 @@ class PulseIn
     onTimeout(Event e);
 
     /**
+    * Method to release the given pin from a peripheral, if already bound.
+    * Device drivers should override this method to disconnect themselves from the give pin
+    * to allow it to be used by a different peripheral.
+    *
+    * @param pin the Pin to be released
+    */
+    virtual int releasePin(Pin &pin) override;
+
+    /**
      * Destructor
      */
-    ~PulseIn();
+    virtual ~PulseIn();
+
+    private:
+    void disable();
 };
 
 }

--- a/inc/drivers/TouchButton.h
+++ b/inc/drivers/TouchButton.h
@@ -120,6 +120,20 @@ namespace codal
         int buttonActive();
 
         /**
+         * Determines the instantneous digital value of the pin associated with this TouchButton
+         *
+         * @return true if a digital read of the attached pin is a logic 1, false otherwise.
+         */
+         int getPinValue();
+
+        /**
+         * Drives a given digital value to the pin associated with this TouchButton
+         *
+         * @param v the digital value to write to the pin associated with this TouchButton.
+         */
+         void setPinValue(int v);
+
+        /**
           * Destructor for Button, where we deregister this instance from the array of fiber components.
           */
         ~TouchButton();

--- a/source/driver-models/I2C.cpp
+++ b/source/driver-models/I2C.cpp
@@ -35,6 +35,18 @@ namespace codal
     }
 
     /**
+      * Change the pins used by this I2C peripheral to those provided.
+      *
+      * @param sda the Pin to use for the I2C SDA line.
+      * @param scl the Pin to use for the I2C SCL line.
+      * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+      */
+    int I2C::redirect(Pin &sda, Pin &scl)
+    {
+        return DEVICE_NOT_IMPLEMENTED;
+    }
+
+    /**
      * Set the frequency of the I2C interface
      *
      * @param frequency The bus frequency in hertz

--- a/source/driver-models/PinPeripheral.cpp
+++ b/source/driver-models/PinPeripheral.cpp
@@ -1,0 +1,67 @@
+/*
+The MIT License (MIT)
+
+Copyright (c) 2022 Lancaster University.
+
+Permission is hereby granted, free of charge, to any person obtaining a
+copy of this software and associated documentation files (the "Software"),
+to deal in the Software without restriction, including without limitation
+the rights to use, copy, modify, merge, publish, distribute, sublicense,
+and/or sell copies of the Software, and to permit persons to whom the
+Software is furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in
+all copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL
+THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING
+FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+DEALINGS IN THE SOFTWARE.
+*/
+
+#include "Pin.h"
+
+using namespace codal;
+
+/**
+ * Method to release the given pin from a peripheral, if already bound.
+ * Device drivers should override this method to disconnect themselves from the give pin
+ * to allow it to be used by a different peripheral.
+ *
+ * @param pin the Pin to be released.
+ * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED if unsupported, or DEVICE_INVALID_PARAMETER if the pin is not bound to this peripheral.
+ */
+int PinPeripheral::releasePin(Pin &pin)
+{
+    return DEVICE_NOT_IMPLEMENTED;
+}
+
+/**
+    * Utility function, to assist in redirect() operations and consistent use of disconnect()/connect() by peripherals.
+    * Safely disconnects pin from any attached peripherals, upfates pin to the new pin, and attaches to the given peripheral.
+    * Also validates out NULL cases.
+    *
+    * @param p Typically a mutable instance variable, holding the current pin used by a given peripheral.
+    * @param newPin The pin which is replacing the value of pin.
+    */
+int PinPeripheral::reassignPin(void *p, Pin *newPin)
+{
+    Pin **pin = (Pin **)p;
+
+    if (pin == NULL)
+        return DEVICE_INVALID_PARAMETER;
+
+    if (*pin && *pin != newPin)
+        (*pin)->disconnect();
+
+    if (newPin)
+        newPin->connect(*this);
+
+    *pin = newPin;   
+
+    return DEVICE_OK;
+}
+

--- a/source/driver-models/PinPeripheral.cpp
+++ b/source/driver-models/PinPeripheral.cpp
@@ -85,19 +85,12 @@ int PinPeripheral::reassignPin(void *p, Pin *newPin)
     if (*pin != newPin)
     {
         if (*pin)
-        {
-            DMESG("DISCONNECTING PIN: %p", *pin);
             (*pin)->disconnect();
-        }
 
         if (newPin)
-        {
-            DMESG("CONNECTING PIN: %p to %p", newPin, this);
             newPin->connect(*this);
-        }
-    
-        DMESG("ASSIGNING PIN: %p to %p", pin, newPin);
-        *pin = newPin;   
+
+        *pin = newPin;
     }
 
     return DEVICE_OK;

--- a/source/driver-models/SPI.cpp
+++ b/source/driver-models/SPI.cpp
@@ -30,6 +30,19 @@ namespace codal
 {
 
 /**
+ * Change the pins used by this I2C peripheral to those provided.
+ *
+ * @param mosi the Pin to use for the SPI input line.
+ * @param miso the Pin to use for the SPI output line.
+ * @param sclk the Pin to use for the SPI clock line.
+ * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED / DEVICE_NOT_SUPPORTED if the request cannot be performed.
+ */
+int SPI::redirect(Pin &mosi, Pin &miso, Pin &sclk)
+{
+    return DEVICE_NOT_IMPLEMENTED;
+}
+
+/**
  * Writes and reads from the SPI bus concurrently. Waits (possibly un-scheduled) for transfer to
  * finish.
  *

--- a/source/driver-models/Serial.cpp
+++ b/source/driver-models/Serial.cpp
@@ -256,7 +256,7 @@ void Serial::circularCopy(uint8_t *circularBuff, uint8_t circularBuffSize, uint8
  *
  *       Buffers aren't allocated until the first send or receive respectively.
  */
-Serial::Serial(Pin& tx, Pin& rx, uint8_t rxBufferSize, uint8_t txBufferSize, uint16_t id) : tx(tx), rx(rx)
+Serial::Serial(Pin& tx, Pin& rx, uint8_t rxBufferSize, uint8_t txBufferSize, uint16_t id) : tx(&tx), rx(&rx)
 {
     this->id = id;
 
@@ -275,6 +275,9 @@ Serial::Serial(Pin& tx, Pin& rx, uint8_t rxBufferSize, uint8_t txBufferSize, uin
 
     this->rxBuffHeadMatch = -1;
 
+    reassignPin(&this->tx, &tx);
+    reassignPin(&this->rx, &rx);
+    
     this->status |= DEVICE_COMPONENT_STATUS_IDLE_TICK;
 }
 
@@ -841,6 +844,9 @@ int Serial::redirect(Pin& tx, Pin& rx)
     lockTx();
     lockRx();
 
+    reassignPin(&this->tx, &tx);
+    reassignPin(&this->rx, &rx);
+    
     if(txBufferedSize() > 0)
         disableInterrupt(TxInterrupt);
 

--- a/source/driver-models/Serial.cpp
+++ b/source/driver-models/Serial.cpp
@@ -275,10 +275,9 @@ Serial::Serial(Pin& tx, Pin& rx, uint8_t rxBufferSize, uint8_t txBufferSize, uin
 
     this->rxBuffHeadMatch = -1;
 
-    DMESG("SERIAL::SERIAL [this:%p] [this->tx:%p[%p]] [this->rx:%p[%p]] [tx:%p] [rx:%p]", this, &this->tx, this->tx, &this->rx, this->rx, &tx, &rx);
     reassignPin(&this->tx, &tx);
     reassignPin(&this->rx, &rx);
-    
+
     this->status |= DEVICE_COMPONENT_STATUS_IDLE_TICK;
 }
 
@@ -845,11 +844,9 @@ int Serial::redirect(Pin& tx, Pin& rx)
     lockTx();
     lockRx();
 
-    DMESG("SERIAL::redirect [this:%p] [this->tx:%p[%p]] [this->rx:%p[%p]] [tx:%p] [rx:%p]", this, &this->tx, this->tx, &this->rx, this->rx, &tx, &rx);
-
     reassignPin(&this->tx, &tx);
     reassignPin(&this->rx, &rx);
-    
+
     if(txBufferedSize() > 0)
         disableInterrupt(TxInterrupt);
 

--- a/source/driver-models/Serial.cpp
+++ b/source/driver-models/Serial.cpp
@@ -275,6 +275,7 @@ Serial::Serial(Pin& tx, Pin& rx, uint8_t rxBufferSize, uint8_t txBufferSize, uin
 
     this->rxBuffHeadMatch = -1;
 
+    DMESG("SERIAL::SERIAL [this:%p] [this->tx:%p[%p]] [this->rx:%p[%p]] [tx:%p] [rx:%p]", this, &this->tx, this->tx, &this->rx, this->rx, &tx, &rx);
     reassignPin(&this->tx, &tx);
     reassignPin(&this->rx, &rx);
     
@@ -843,6 +844,8 @@ int Serial::redirect(Pin& tx, Pin& rx)
 
     lockTx();
     lockRx();
+
+    DMESG("SERIAL::redirect [this:%p] [this->tx:%p[%p]] [this->rx:%p[%p]] [tx:%p] [rx:%p]", this, &this->tx, this->tx, &this->rx, this->rx, &tx, &rx);
 
     reassignPin(&this->tx, &tx);
     reassignPin(&this->rx, &rx);

--- a/source/driver-models/Timer.cpp
+++ b/source/driver-models/Timer.cpp
@@ -374,6 +374,8 @@ void Timer::trigger(bool isFallback)
                     uint16_t id = e->id;
                     uint16_t value = e->value;
 
+
+
                     // Release before triggering event. Otherwise, an immediate event handler
                     // can cancel this event, another event might be put in its place
                     // and we end up releasing (or repeating) a completely different event.

--- a/source/drivers/Button.cpp
+++ b/source/drivers/Button.cpp
@@ -173,6 +173,26 @@ int Button::isPressed()
 }
 
 /**
+ * Method to release the given pin from a peripheral, if already bound.
+ * Device drivers should override this method to disconnect themselves from the give pin
+ * to allow it to be used by a different peripheral.
+ *
+ * @param pin the Pin to be released.
+ * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED if unsupported, or DEVICE_INVALID_PARAMETER if the pin is not bound to this peripheral.
+ */
+int Button::releasePin(Pin &pin)
+{
+    // We've been asked to disconnect from the given pin.
+    // Stop requesting periodic callbacks from the scheduler.
+    this->status &= ~DEVICE_COMPONENT_STATUS_SYSTEM_TICK;
+
+    if (deleteOnRelease)
+        delete this;
+
+    return DEVICE_OK;
+}
+
+/**
   * Destructor for Button, where we deregister this instance from the array of fiber components.
   */
 Button::~Button()

--- a/source/drivers/Button.cpp
+++ b/source/drivers/Button.cpp
@@ -86,7 +86,13 @@ void Button::setEventConfiguration(ButtonEventConfiguration config)
  */
 int Button::buttonActive()
 {
-    return _pin.getDigitalValue() == polarity;
+    bool active;
+    
+    setPinLock(true);
+    active = _pin.getDigitalValue() == polarity;
+    setPinLock(false);
+
+    return active;
 }
 
 /**

--- a/source/drivers/Button.cpp
+++ b/source/drivers/Button.cpp
@@ -87,7 +87,7 @@ void Button::setEventConfiguration(ButtonEventConfiguration config)
 int Button::buttonActive()
 {
     bool active;
-    
+
     setPinLock(true);
     active = _pin.getDigitalValue() == polarity;
     setPinLock(false);

--- a/source/drivers/PulseIn.cpp
+++ b/source/drivers/PulseIn.cpp
@@ -118,9 +118,26 @@ PulseIn::onTimeout(Event e)
 }
 
 /**
- * Destructor
+ * Method to release the given pin from a peripheral, if already bound.
+ * Device drivers should override this method to disconnect themselves from the give pin
+ * to allow it to be used by a different peripheral.
+ *
+ * @param pin the Pin to be released.
+ * @return DEVICE_OK on success, or DEVICE_NOT_IMPLEMENTED if unsupported, or DEVICE_INVALID_PARAMETER if the pin is not bound to this peripheral.
  */
-PulseIn::~PulseIn()
+int PulseIn::releasePin(Pin &pin)
+{
+    // We've been asked to disconnect from the given pin.
+    // As we do nothing else, simply disable ourselves.
+    disable();
+
+    if (deleteOnRelease)
+        delete this;
+
+    return DEVICE_OK;
+}
+
+void PulseIn::disable()
 {
     if (enabled)
     {
@@ -132,4 +149,12 @@ PulseIn::~PulseIn()
         lastPeriod = 0;
         lock.notifyAll();
     }
+}
+
+/**
+ * Destructor
+ */
+PulseIn::~PulseIn()
+{
+    disable();
 }

--- a/source/drivers/TouchButton.cpp
+++ b/source/drivers/TouchButton.cpp
@@ -104,6 +104,34 @@ int TouchButton::getThreshold()
 }
 
 /**
+ * Determines the instantneous digital value of the pin associated with this TouchButton
+ *
+ * @return true if a digital read of the attached pin is a logic 1, false otherwise.
+ */
+int TouchButton::getPinValue()
+{
+    int result;
+
+    setPinLock(true);
+    result = _pin.getDigitalValue();
+    setPinLock(false);
+
+    return result;
+}
+
+/**
+ * Drives a given digital value to the pin associated with this TouchButton
+ *
+ * @param v the digital value to write to the pin associated with this TouchButton.
+ */
+void TouchButton::setPinValue(int v)
+{
+    setPinLock(true);
+    _pin.setDigitalValue(v);
+    setPinLock(false);
+}
+
+/**
  * Determine the last reading taken from this button.
  *
  * @return the last reading taken.

--- a/source/drivers/TouchSensor.cpp
+++ b/source/drivers/TouchSensor.cpp
@@ -92,7 +92,7 @@ int TouchSensor::addTouchButton(TouchButton *button)
     numberOfButtons++;
 
     // Put the button into input mode.
-    button->_pin.getDigitalValue();
+    button->getPinValue();
 
     return DEVICE_OK;
 }
@@ -149,7 +149,7 @@ void TouchSensor::onSampleEvent(Event)
         {
             if (buttons[i]->active)
             {
-                if(buttons[i]->_pin.getDigitalValue() == 1 || cycles >= (buttons[i]->threshold))
+                if(buttons[i]->getPinValue() == 1 || cycles >= (buttons[i]->threshold))
                 {
                     buttons[i]->active = false;
                     buttons[i]->setValue(cycles);


### PR DESCRIPTION
Introduces cleaner and more scalable interface for dynamic management of how pins are bound to peripherals.

In short, provides the necessary plumbing to enable targets to track which pins are used by which peripherals, and more consistently connect/disconnect and reuse pins at run time. Provides necessary groundwork to resolve issues such as: https://github.com/lancaster-university/codal-microbit-v2/issues/226

Summary of changes:

- Introduce PinPeriheral interface, with well defined methods for locking and requesting the release of a peripheral's pin resources.
- Updates to Pin interface, to more explicitly control runtime connection and disconnection of pins from peripherals.
- Addition of redirect() methods for SPI and I2C base classes (and making associated variables mutable pointers rather than immutable references).
- Implementation of default PinPeripheral interface by relevant peripheral base classes.
- Cleanup of Button/TouchButton pin accessor methods to avoid unnecessary breaking of encapsulation.