### PR TITLE
Compass::clearCalibration() resets calibration member variable

### DIFF
--- a/source/driver-models/Compass.cpp
+++ b/source/driver-models/Compass.cpp
@@ -223,6 +223,7 @@ int Compass::isCalibrating()
  */
 void Compass::clearCalibration()
 {
+    calibration = CompassCalibration();
     status &= ~COMPASS_STATUS_CALIBRATED;
 }
 


### PR DESCRIPTION
Fixes recalibration.
See https://github.com/lancaster-university/codal-microbit-v2/issues/286#issuecomment-1484243324