### PR TITLE
Set default DEVICE_DMESG_BUFFER_SIZE based on DEVICE_DMESG.

### DIFF
--- a/inc/core/CodalConfig.h
+++ b/inc/core/CodalConfig.h
@@ -153,15 +153,28 @@ DEALINGS IN THE SOFTWARE.
 //
 // Debug options
 //
-#ifndef DEVICE_DMESG
-#define DEVICE_DMESG                          0
+#ifndef DMESG_SERIAL_DEBUG
+  #define DMESG_SERIAL_DEBUG                  0
+#else
+  // Automatically enable DMESG_ENABLE if DMESG_SERIAL_DEBUG is set
+  #if DMESG_SERIAL_DEBUG > 0
+    #define DMESG_ENABLE                      1
+  #endif
+#endif
+
+#ifndef DMESG_ENABLE
+#define DMESG_ENABLE                          0
 #endif
 
 // When non-zero internal debug messages (DMESG() macro) go to a in-memory buffer of this size (in bytes).
 // It can be inspected from GDB (with 'print codalLogStore'), or accessed by the application.
 // Typical size range between 512 and 4096. Set to 0 to disable.
 #ifndef DEVICE_DMESG_BUFFER_SIZE
-#define DEVICE_DMESG_BUFFER_SIZE              1024
+  #if DMESG_ENABLE > 0
+    #define DEVICE_DMESG_BUFFER_SIZE          1024
+  #else
+    #define DEVICE_DMESG_BUFFER_SIZE          0
+  #endif
 #endif
 
 #ifndef CODAL_DEBUG


### PR DESCRIPTION
The value in `DEVICE_DMESG_BUFFER_SIZE` configures if the debug messages log/buffer is compiled or not.

Currently the only way not to compile the debug buffer is by setting `DEVICE_DMESG_BUFFER_SIZE` to 0, either in codal.json on the target.json files. This is non-obvious and not documented anywhere:
- https://github.com/lancaster-university/codal-microbit-v2/issues/297

Currently `DEVICE_DMESG` doesn't do anything:
- https://github.com/lancaster-university/codal-microbit-v2/issues/296

We normally use `DMESG_SERIAL_DEBUG` to enable debug data to be printed to serial, but there is also a use-case of having the debug log/buffer in RAM to be able to access it via debugger. `DEVICE_DMESG` should probably be used to enable/disable the debug log, and additionally `DMESG_SERIAL_DEBUG` would be set to print it to serial (and not only keep it in RAM).

So, the user should be able disable all debug logging when the `DMESG_SERIAL_DEBUG` is set to zero, which this PR does (as long as the target.json file doesn't set `DEVICE_DMESG_BUFFER_SIZE`, which would overwrite the defaults from `CodalConfig.h`).