### PR TITLE
[Clang compatibility] Preprocessor Directives to ignore builtin clang function

### DIFF
--- a/inc/core/codal_target_hal.h
+++ b/inc/core/codal_target_hal.h
@@ -82,16 +82,19 @@ extern "C"
 
     void tcb_configure_args(void* tcb, PROCESSOR_WORD_TYPE ep, PROCESSOR_WORD_TYPE cp, PROCESSOR_WORD_TYPE pm);
 
-    /**
-     * Default implementation of atomic fetch and add opertaion.
-     * GCC provides this where possible, but this is not supported on some CPU architectures...
-     *
-     * @param ptr pointer to the memory to access.
-     * @param value the value to add to the memory location.
-     * @return the value of th ememory location BEFORE the add operation took place.
-     */
-    short unsigned int __sync_fetch_and_add_2 (volatile void *ptr, short unsigned int value);
-
+	// Preprocessor Directive to ignore redecleration when using clang
+    #ifndef __clang__
+		/**
+		 * Default implementation of atomic fetch and add opertaion.
+		 * GCC provides this where possible, but this is not supported on some CPU architectures...
+		 *
+		 * @param ptr pointer to the memory to access.
+		 * @param value the value to add to the memory location.
+		 * @return the value of th ememory location BEFORE the add operation took place.
+		 */
+		short unsigned int __sync_fetch_and_add_2 (volatile void *ptr, short unsigned int value);
+    
+    #endif
 }
 
 // This is re-defined in targets with external flash, that require certain functions to be placed in RAM

--- a/source/core/codal_default_target_hal.cpp
+++ b/source/core/codal_default_target_hal.cpp
@@ -46,28 +46,31 @@ __attribute__((weak)) void target_deepsleep()
     target_wait_for_event();
 }
 
-/**
- * Default implementation of atomic fetch and add opertaion.
- * GCC provides this where possible, but this is not supported on some CPU architectures...
- *
- * @param ptr pointer to the memory to access.
- * @param value the value to add to the memory location.
- * @return the value of th ememory location BEFORE the add operation took place.
- */
-__attribute__((weak)) short unsigned int __sync_fetch_and_add_2 (volatile void *ptr, short unsigned int value)
-{
+// Preprocessor Directive to ignore redecleration when using clang
+#ifndef __clang__
+	/**
+	 * Default implementation of atomic fetch and add opertaion.
+	 * GCC provides this where possible, but this is not supported on some CPU architectures...
+	 *
+	 * @param ptr pointer to the memory to access.
+	 * @param value the value to add to the memory location.
+	 * @return the value of th ememory location BEFORE the add operation took place.
+	 */
+	__attribute__((weak)) short unsigned int __sync_fetch_and_add_2 (volatile void *ptr, short unsigned int value)
+	{
 
-#if CONFIG_ENABLED(DISABLE_IRQ_FOR_SOFTWARE_ATOMICS)
-    target_disable_irq();
+	#if CONFIG_ENABLED(DISABLE_IRQ_FOR_SOFTWARE_ATOMICS)
+		target_disable_irq();
+	#endif
+
+		uint16_t *p = (uint16_t *)ptr;
+		uint16_t old = *p;
+		*p += value;
+
+	#if CONFIG_ENABLED(DISABLE_IRQ_FOR_SOFTWARE_ATOMICS)
+		target_enable_irq();
+	#endif
+
+		return old;
+	}
 #endif
-
-    uint16_t *p = (uint16_t *)ptr;
-    uint16_t old = *p;
-    *p += value;
-
-#if CONFIG_ENABLED(DISABLE_IRQ_FOR_SOFTWARE_ATOMICS)
-    target_enable_irq();
-#endif
-
-    return old;
-}


### PR DESCRIPTION
__sync_fetch_and_add_2() is a clang builtin, do not declare this function separately when building with clang.