### PR TITLE
Make `AbstractButton::isPressed()` pure virtual.

### DIFF
--- a/inc/driver-models/AbstractButton.h
+++ b/inc/driver-models/AbstractButton.h
@@ -92,7 +92,7 @@ namespace codal
           *
           * @return 1 if this button is pressed, 0 otherwise.
           */
-        virtual int isPressed();
+        virtual int isPressed() = 0;
 
         /**
           * Determines if this button has been pressed.

--- a/source/driver-models/AbstractButton.cpp
+++ b/source/driver-models/AbstractButton.cpp
@@ -41,21 +41,6 @@ AbstractButton::AbstractButton()
 }
 
 /**
- * Tests if this Button is currently pressed.
- *
- * @code
- * if(buttonA.isPressed())
- *     display.scroll("Pressed!");
- * @endcode
- *
- * @return 1 if this button is pressed, 0 otherwise.
- */
-int AbstractButton::isPressed()
-{
-    return 0;
-}
-
-/**
  * Determines if this button has been pressed.
  *
  * @code


### PR DESCRIPTION
This saves about 40 bytes of flash with gcc v10.3.1 & the codal-microbit-v2 build configuration.

And, as it might be removing the entry in the vtable for the derived classes, it could be a bit more efficient too.

Related to:
- https://github.com/lancaster-university/codal-core/pull/162
- https://github.com/lancaster-university/codal-core/pull/164