### PR TITLE
gcc 12.x.x compatibility functions - newlib support

### DIFF
--- a/inc/core/gcc_compat.h
+++ b/inc/core/gcc_compat.h
@@ -1,0 +1,15 @@
+#ifndef GCC_COMPAT_H
+#define GCC_COMPAT_H
+
+#if __GNUC__ > 11
+extern "C" {
+    int _close( int fd );
+    int _getpid();
+    int _kill(int pid, int sig);
+    int _lseek(int file, int ptr, int dir);
+    int _read(int file, char *ptr, int len);
+    int _write(int file, char *ptr, int len);
+}
+#endif
+
+#endif

--- a/inc/core/gcc_compat.h
+++ b/inc/core/gcc_compat.h
@@ -3,12 +3,12 @@
 
 #if __GNUC__ > 11
 extern "C" {
-    int _close( int fd );
-    int _getpid();
-    int _kill(int pid, int sig);
-    int _lseek(int file, int ptr, int dir);
-    int _read(int file, char *ptr, int len);
-    int _write(int file, char *ptr, int len);
+    int _close( int fd ) __attribute__((weak));
+    int _getpid() __attribute__((weak));
+    int _kill(int pid, int sig) __attribute__((weak));
+    int _lseek(int file, int ptr, int dir) __attribute__((weak));
+    int _read(int file, char *ptr, int len) __attribute__((weak));
+    int _write(int file, char *ptr, int len) __attribute__((weak));
 }
 #endif
 

--- a/source/core/gcc_compat.cpp
+++ b/source/core/gcc_compat.cpp
@@ -2,6 +2,7 @@
 #include "codal_target_hal.h"
 #include "CodalAssert.h"
 
+#if __GNUC__ > 11
 extern "C" {
     int _close( int fd )
     {
@@ -38,3 +39,4 @@ extern "C" {
         return -1;
     }
 }
+#endif

--- a/source/core/gcc_compat.cpp
+++ b/source/core/gcc_compat.cpp
@@ -1,0 +1,40 @@
+#include "gcc_compat.h"
+#include "codal_target_hal.h"
+#include "CodalAssert.h"
+
+extern "C" {
+    int _close( int fd )
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+
+    int _getpid()
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+
+    int _kill(int pid, int sig)
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+
+    int _lseek(int file, int ptr, int dir)
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+
+    int _read(int file, char *ptr, int len)
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+    int _write(int file, char *ptr, int len)
+    {
+        assert_fault( "Newlib syscalls are not supported!" );
+        return -1;
+    }
+}


### PR DESCRIPTION
> Added a set of C function hooks to patch holes in the Newlib API to squash the GCC v12+ warnings.

This adds the missing functions that gcc-11 and gcc-12 seem to want despite being in -lnosys mode. The warnings don't break the build, but cause a smattering of errors throughout.