### PR TITLE
Display scroll an empty char if the requested char is out-of-range. 

### DIFF
--- a/source/drivers/AnimatedDisplay.cpp
+++ b/source/drivers/AnimatedDisplay.cpp
@@ -145,6 +145,9 @@ void AnimatedDisplay::updateScrollText()
     if (scrollingPosition < BITMAP_FONT_WIDTH && scrollingChar < scrollingText.length())
     {
         const uint8_t *v = font.get(scrollingText.charAt(scrollingChar));
+        if (v == NULL) {
+            v = font.get(' ');
+        }
         uint8_t mask = 1 << (BITMAP_FONT_WIDTH - scrollingPosition - 1);
         uint8_t x = display.getWidth()-1;
 


### PR DESCRIPTION
Currently it was scrolling a NULL pointer:
- https://github.com/lancaster-university/codal-microbit-v2/issues/423

This matches the V1 and MakeCode sim behaviour.