### PR TITLE
Ensure .cpp files are `using namespace codal`.

### DIFF
--- a/inc/driver-models/Pin.h
+++ b/inc/driver-models/Pin.h
@@ -60,8 +60,6 @@ DEALINGS IN THE SOFTWARE.
 
 namespace codal
 {
-    using namespace codal;
-
     /**
       * Pin capabilities enum.
       * Used to determine the capabilities of each Pin as some can only be digital, or can be both digital and analogue.

--- a/inc/types/Matrix4.h
+++ b/inc/types/Matrix4.h
@@ -27,6 +27,9 @@ DEALINGS IN THE SOFTWARE.
 
 #include "CodalConfig.h"
 
+namespace codal
+{
+
 /**
 * Class definition for a simple matrix, that is optimised for nx4 or 4xn matrices.
 *
@@ -197,5 +200,7 @@ inline Matrix4 Matrix4::multiplyT(Matrix4 &matrix)
 {
     return multiply(matrix, true);
 }
+
+} // namespace codal
 
 #endif

--- a/source/driver-models/CodalUSB.cpp
+++ b/source/driver-models/CodalUSB.cpp
@@ -38,6 +38,8 @@ DEALINGS IN THE SOFTWARE.
 #include "CodalDmesg.h"
 #include "codal_target_hal.h"
 
+using namespace codal;
+
 #define send(p, l) ctrlIn->write(p, l)
 
 CodalUSB *CodalUSB::usbInstance = NULL;

--- a/source/types/Matrix4.cpp
+++ b/source/types/Matrix4.cpp
@@ -25,6 +25,8 @@ DEALINGS IN THE SOFTWARE.
 #include "CodalConfig.h"
 #include "Matrix4.h"
 
+using namespace codal;
+
 /**
 * Class definition for a simple matrix, optimised for n x 4 or 4 x n matrices.
 *


### PR DESCRIPTION
And ensures header files declare new classes in the codal namespace.

This is part of:
- https://github.com/lancaster-university/codal-microbit-v2/issues/240

Haven't touched the CodalUSB.h header file to declare its classes inside the codal namespace, as this file is not used by the codal-microbit-v2 target and could affect other targets using it.