### PR TITLE
Add config flag to enable/disable adding codal to the global namespace.

### DIFF
--- a/inc/core/CodalConfig.h
+++ b/inc/core/CodalConfig.h
@@ -228,6 +228,15 @@ DEALINGS IN THE SOFTWARE.
   #define CODAL_STREAM_IDLE_TIMEOUT_MS   75
 #endif
 
+// During early CODAL development there was some misuse of `using namespace codal;` in header files.
+// Removing it from CODAL libs can cause targets to break unless they apply a large patch like:
+// https://github.com/lancaster-university/codal-microbit-v2/pull/437
+// This global namespace can be a problem when using CODAL together with other libraries/frameworks.
+// So we can use this flag to enable/disable whether to use the codal namespace globally or not.
+#ifndef CODAL_USE_GLOBAL_NAMESPACE
+  #define CODAL_USE_GLOBAL_NAMESPACE 1
+#endif
+
 //
 // Helper macro used by the codal device runtime to determine if a boolean configuration option is set.
 //


### PR DESCRIPTION
Flag mostly to be used in other CODAL libraries/targets.

This is part of:
- https://github.com/lancaster-university/codal-microbit-v2/issues/240

As removing 'using namespace codal' from `codal-nrf52` can break a few targets, this patch adds a CODAL flag/macro to enable/disable its usage.