### PR TITLE
Set `LEVEL_DETECTOR_SPL_8BIT_000_POINT` to 52.0 dB.

### DIFF
--- a/inc/streams/LevelDetectorSPL.h
+++ b/inc/streams/LevelDetectorSPL.h
@@ -58,7 +58,7 @@ DEALINGS IN THE SOFTWARE.
 
 // The level (in dB) that corresponds to an 8bit value of 0.
 #ifndef LEVEL_DETECTOR_SPL_8BIT_000_POINT
-#define LEVEL_DETECTOR_SPL_8BIT_000_POINT                   35.0f
+#define LEVEL_DETECTOR_SPL_8BIT_000_POINT                   52.0f
 #endif
 
 // The level (in dB) that corresponds to an 8bit value of 255.


### PR DESCRIPTION
This is the value currently used by MakeCode:
https://github.com/microsoft/pxt-microbit/blob/v7.1.3/libs/microphone/microphone.cpp#L8

And MicroPython:
https://github.com/microbit-foundation/micropython-microbit-v2/blob/v2.1.2/src/codal_app/codal.json#L16

The reason to change it is that the LevelDetectorSPL() minValue default parameter is already 52:
https://github.com/lancaster-university/codal-core/blob/509086cc8590465041b15493ab52b56e7071c110/inc/streams/LevelDetectorSPL.h#L123-L126

MicroBitAudio also sets it to the same value 52.0:
https://github.com/lancaster-university/codal-microbit-v2/blob/v0.2.68/source/MicroBitAudio.cpp#L82

And LevelDetectorSPL will clamp as that being the min. https://github.com/lancaster-university/codal-core/blob/509086cc8590465041b15493ab52b56e7071c110/source/streams/LevelDetectorSPL.cpp#L142-L147

Fixes https://github.com/lancaster-university/codal-microbit-v2/issues/449.