### PR TITLE
StreamRecording - calculate memory overhead of buffers

### DIFF
--- a/inc/streams/StreamRecording.h
+++ b/inc/streams/StreamRecording.h
@@ -37,11 +37,14 @@ namespace codal
         StreamRecording_Buffer * readHead;
         uint32_t maxBufferLenth;
         uint32_t totalBufferLength;
+        uint32_t totalMemoryUsage;
         int state;
         float lastUpstreamRate;
 
         DataSink *downStream;
         DataSource &upStream;
+
+        void initialise();
 
         public:
 


### PR DESCRIPTION
WORK IN PROGRESS - DO NOT MERGE

Possible workaround for https://github.com/lancaster-university/codal-microbit-v2/issues/450.

Adds a variable to shadow totalBufferLength, and accumulate the memory overhead of adding each buffer. The limit is then the total memory usage, rather than totalBufferLength.

Adjusts maxBufferLength, so the default case with 256 byte buffers still records the same amount of data.