### PR TITLE
Ensure float literals and float versions of math functions are used.

### DIFF
--- a/source/driver-models/Accelerometer.cpp
+++ b/source/driver-models/Accelerometer.cpp
@@ -426,7 +426,7 @@ int Accelerometer::getZ()
   */
 int Accelerometer::getPitch()
 {
-    return (int) ((360*getPitchRadians()) / (2*PI));
+    return (int) ((360.0f*getPitchRadians()) / (2.0f*(float)PI));
 }
 
 /**
@@ -458,7 +458,7 @@ float Accelerometer::getPitchRadians()
   */
 int Accelerometer::getRoll()
 {
-    return (int) ((360*getRollRadians()) / (2*PI));
+    return (int) ((360.0f*getRollRadians()) / (2.0f*(float)PI));
 }
 
 /**

--- a/source/driver-models/Compass.cpp
+++ b/source/driver-models/Compass.cpp
@@ -371,16 +371,16 @@ int Compass::tiltCompensatedBearing()
     float z = (float) s.z;
 
     // Precompute cos and sin of pitch and roll angles to make the calculation a little more efficient.
-    float sinPhi = sin(phi);
-    float cosPhi = cos(phi);
-    float sinTheta = sin(theta);
-    float cosTheta = cos(theta);
+    float sinPhi = sinf(phi);
+    float cosPhi = cosf(phi);
+    float sinTheta = sinf(theta);
+    float cosTheta = cosf(theta);
 
      // Calculate the tilt compensated bearing, and convert to degrees.
-    float bearing = (360*atan2(x*cosTheta + y*sinTheta*sinPhi + z*sinTheta*cosPhi, z*sinPhi - y*cosPhi)) / (2*PI);
+    float bearing = (360.0f*atan2f(x*cosTheta + y*sinTheta*sinPhi + z*sinTheta*cosPhi, z*sinPhi - y*cosPhi)) / (2.0f*(float)PI);
 
     // Handle the 90 degree offset caused by the NORTH_EAST_DOWN based calculation.
-    bearing = 90 - bearing;
+    bearing = 90.0f - bearing;
 
     // Ensure the calculated bearing is in the 0..359 degree range.
     if (bearing < 0)
@@ -399,10 +399,10 @@ int Compass::basicBearing()
     float x = (float) cs.x;
     float y = (float) cs.y;
 
-    float bearing = (atan2(x,y))*180/PI;
+    float bearing = (atan2f(x,y))*180.0f/(float)PI;
 
     if (bearing < 0)
-        bearing += 360.0;
+        bearing += 360.0f;
 
     return (int)bearing;
 }

--- a/source/streams/LevelDetectorSPL.cpp
+++ b/source/streams/LevelDetectorSPL.cpp
@@ -131,13 +131,13 @@ int LevelDetectorSPL::pullRequest()
             sumSquares += v * v;
             ptr += skip;
         }
-        float rms = sqrt(sumSquares / count);
+        float rms = sqrtf(sumSquares / count);
 
         /*******************************
         *   CALCULATE SPL
         ******************************/
         float conv = ((float) maxVal * multiplier) / ((1 << 15) - 1) * gain;
-        conv = 20 * log10(conv / pref);
+        conv = 20.0f * log10f(conv / pref);
 
         if (conv < minValue)
             level = minValue;

--- a/source/streams/StreamNormalizer.cpp
+++ b/source/streams/StreamNormalizer.cpp
@@ -209,7 +209,7 @@ ManagedBuffer StreamNormalizer::pull()
     {
         float calculatedZeroOffset = (float)z / (float)samples;
 
-        zeroOffset = zeroOffsetValid ? zeroOffset*0.5 + calculatedZeroOffset*0.5 : calculatedZeroOffset;
+        zeroOffset = zeroOffsetValid ? zeroOffset*0.5f + calculatedZeroOffset*0.5f : calculatedZeroOffset;
         zeroOffsetValid = true;
 
         if (stabilisation == 0 || abs((int)zeroOffset - zo) < stabilisation)

--- a/source/streams/Synthesizer.cpp
+++ b/source/streams/Synthesizer.cpp
@@ -152,7 +152,7 @@ int Synthesizer::setFrequency(float frequency, int period, int envelopeStart, in
         return DEVICE_BUSY;
 
     // record our new intended frequency.
-    newPeriodNs = frequency == 0.0 ? 0 : (uint32_t) (1000000000.0f / frequency);
+    newPeriodNs = frequency == 0.0f ? 0 : (uint32_t) (1000000000.0f / frequency);
 
     if (period == 0)
     {


### PR DESCRIPTION
Specifically for `LevelDetectorSPL::pullRequest()`, as float in the micro:bit's Cortex-M4f is much faster and this function runs a lot in the background.

Related PR:
- https://github.com/lancaster-university/codal-microbit-v2/pull/454