### PR TITLE
DataSource interface extension for Bug fixes for rare glitches on WS2812B pixels (NeoPixels) and 030 errors on micro:bit V2 (2/3)

### DIFF
--- a/inc/streams/DataStream.h
+++ b/inc/streams/DataStream.h
@@ -72,7 +72,7 @@ namespace codal
 
     	public:
             virtual ManagedBuffer pull();
-            virtual void pull(ManagedBuffer &bufffer);
+            virtual void pull(ManagedBuffer &buffer);
             virtual void connect(DataSink &sink);
             virtual bool isConnected() { return false; }
             virtual void disconnect();

--- a/inc/streams/DataStream.h
+++ b/inc/streams/DataStream.h
@@ -72,6 +72,7 @@ namespace codal
 
     	public:
             virtual ManagedBuffer pull();
+            virtual void pull(ManagedBuffer &bufffer);
             virtual void connect(DataSink &sink);
             virtual bool isConnected() { return false; }
             virtual void disconnect();

--- a/source/core/CodalHeapAllocator.cpp
+++ b/source/core/CodalHeapAllocator.cpp
@@ -207,6 +207,9 @@ void *device_malloc_in(size_t size, HeapDefinition &heap)
     // Disable IRQ temporarily to ensure no race conditions!
     target_disable_irq();
 
+    // // Account for the index block;
+    // blocksNeeded++;
+
     // We implement a first fit algorithm with cache to handle rapid churn...
     // We also defragment free blocks as we search, to optimise this and future searches.
     block = heap.heap_start;

--- a/source/core/CodalHeapAllocator.cpp
+++ b/source/core/CodalHeapAllocator.cpp
@@ -207,9 +207,6 @@ void *device_malloc_in(size_t size, HeapDefinition &heap)
     // Disable IRQ temporarily to ensure no race conditions!
     target_disable_irq();
 
-    // // Account for the index block;
-    // blocksNeeded++;
-
     // We implement a first fit algorithm with cache to handle rapid churn...
     // We also defragment free blocks as we search, to optimise this and future searches.
     block = heap.heap_start;

--- a/source/streams/DataStream.cpp
+++ b/source/streams/DataStream.cpp
@@ -40,8 +40,9 @@ ManagedBuffer DataSource::pull()
 	return ManagedBuffer();
 }
 
-void DataSource::pull(ManagedBuffer &bufffer)
+void DataSource::pull(ManagedBuffer &buffer)
 {
+    buffer = pull();
 }
 
 void DataSource::connect(DataSink& )

--- a/source/streams/DataStream.cpp
+++ b/source/streams/DataStream.cpp
@@ -40,6 +40,10 @@ ManagedBuffer DataSource::pull()
 	return ManagedBuffer();
 }
 
+void DataSource::pull(ManagedBuffer &bufffer)
+{
+}
+
 void DataSource::connect(DataSink& )
 {
 }


### PR DESCRIPTION
This adds an additional version of the `pull()` member function to the `DataSource` with a default implentation which simply calls the original one. This should be harmless for existing code and is required for more effficient use of `ManageBuffer` in `WS2812B` + `NRF52PWM`.

---

Partner PRs:
 - https://github.com/lancaster-university/codal-nrf52/pull/61
 - https://github.com/lancaster-university/codal-microbit-v2/pull/505

