### PR TITLE
ST7735 driver fix for screen hanging.

### DIFF
--- a/inc/drivers/ST7735.h
+++ b/inc/drivers/ST7735.h
@@ -53,7 +53,7 @@ protected:
     uint8_t cmdBuf[20];
     ST7735WorkBuffer *work;
     bool inSleepMode;
-    FiberLock displayIsFree;
+    FiberLock inProgressLock;
 
     // if true, every pixel will be plotted as 4 pixels and 16 bit color mode
     // will be used; this is for ILI9341 which usually has 320x240 screens

--- a/inc/drivers/ST7735.h
+++ b/inc/drivers/ST7735.h
@@ -29,6 +29,7 @@ DEALINGS IN THE SOFTWARE.
 #include "SPI.h"
 #include "Event.h"
 #include "ScreenIO.h"
+#include "CodalFiber.h"
 
 namespace codal
 {
@@ -52,6 +53,7 @@ protected:
     uint8_t cmdBuf[20];
     ST7735WorkBuffer *work;
     bool inSleepMode;
+    FiberLock displayIsFree;
 
     // if true, every pixel will be plotted as 4 pixels and 16 bit color mode
     // will be used; this is for ILI9341 which usually has 320x240 screens
@@ -65,12 +67,12 @@ protected:
 
     void sendCmd(uint8_t *buf, int len);
     void sendCmdSeq(const uint8_t *buf);
-    void sendDone(Event);
     void sendWords(unsigned numBytes);
     void startTransfer(unsigned size);
     void sendBytes(unsigned num);
     void startRAMWR(int cmd = 0);
 
+    static void sendDone(ST7735* st);
     static void sendColorsStep(ST7735 *st);
 
 public:

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -65,7 +65,8 @@
 namespace codal
 {
 
-ST7735::ST7735(ScreenIO &io, Pin &cs, Pin &dc) : io(io), cs(&cs), dc(&dc), work(NULL)
+ST7735::ST7735(ScreenIO &io, Pin &cs, Pin &dc)
+    : io(io), cs(&cs), dc(&dc), work(NULL), displayIsFree(1)
 {
     double16 = false;
     inSleepMode = false;
@@ -145,7 +146,7 @@ struct ST7735WorkBuffer
     unsigned x;
     uint32_t *paletteTable;
     unsigned srcLeft;
-    bool inProgress;
+    volatile bool inProgress;
     uint32_t expPalette[256];
 };
 
@@ -269,7 +270,7 @@ void ST7735::sendColorsStep(ST7735 *st)
         if (work->srcLeft == 0)
         {
             st->endCS();
-            Event(DEVICE_ID_DISPLAY, 100);
+            st->sendDone(st);
         }
         else
         {
@@ -287,6 +288,8 @@ void ST7735::sendColorsStep(ST7735 *st)
 
 void ST7735::startTransfer(unsigned size)
 {
+    // io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendDone, this);
+    // io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendColorsStep, this);
     io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendColorsStep, this);
 }
 
@@ -301,18 +304,19 @@ void ST7735::startRAMWR(int cmd)
     beginCS();
 }
 
-void ST7735::sendDone(Event)
+void ST7735::sendDone(ST7735 *st)
 {
     // this executes outside of interrupt context, so we don't get a race
     // with waitForSendDone
-    work->inProgress = false;
-    Event(DEVICE_ID_DISPLAY, 101);
+    st->work->inProgress = false;
+    st->displayIsFree.notify();
 }
 
 void ST7735::waitForSendDone()
 {
-    if (work && work->inProgress)
-        fiber_wait_for_event(DEVICE_ID_DISPLAY, 101);
+    // if (!work)
+    //     return;
+    // displayIsFree.wait();
 }
 
 int ST7735::setSleep(bool sleepMode)
@@ -355,9 +359,10 @@ int ST7735::sendIndexedImage(const uint8_t *src, unsigned width, unsigned height
         else
             for (int i = 0; i < 256; ++i)
                 work->expPalette[i] = 0x1011 * (i & 0xf) | (0x110100 * (i >> 4));
-        EventModel::defaultEventBus->listen(DEVICE_ID_DISPLAY, 100, this, &ST7735::sendDone);
+        // EventModel::defaultEventBus->listen(DEVICE_ID_DISPLAY, 100, this, &ST7735::sendDone);
     }
 
+    displayIsFree.wait();
     if (work->inProgress || inSleepMode)
         return DEVICE_BUSY;
 

--- a/source/drivers/ST7735.cpp
+++ b/source/drivers/ST7735.cpp
@@ -66,7 +66,7 @@ namespace codal
 {
 
 ST7735::ST7735(ScreenIO &io, Pin &cs, Pin &dc)
-    : io(io), cs(&cs), dc(&dc), work(NULL), displayIsFree(1)
+    : io(io), cs(&cs), dc(&dc), work(NULL), inProgressLock(1)
 {
     double16 = false;
     inSleepMode = false;
@@ -146,7 +146,6 @@ struct ST7735WorkBuffer
     unsigned x;
     uint32_t *paletteTable;
     unsigned srcLeft;
-    volatile bool inProgress;
     uint32_t expPalette[256];
 };
 
@@ -288,8 +287,6 @@ void ST7735::sendColorsStep(ST7735 *st)
 
 void ST7735::startTransfer(unsigned size)
 {
-    // io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendDone, this);
-    // io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendColorsStep, this);
     io.startSend(work->dataBuf, size, (PVoidCallback)&ST7735::sendColorsStep, this);
 }
 
@@ -306,18 +303,14 @@ void ST7735::startRAMWR(int cmd)
 
 void ST7735::sendDone(ST7735 *st)
 {
-    // this executes outside of interrupt context, so we don't get a race
-    // with waitForSendDone
-    st->work->inProgress = false;
-    st->displayIsFree.notify();
+    st->inProgressLock.notify();
 }
 
-void ST7735::waitForSendDone()
-{
-    // if (!work)
-    //     return;
-    // displayIsFree.wait();
-}
+
+/**
+* Deprecated; no longer neccessary. sendIndexedImage handles this.
+*/
+void ST7735::waitForSendDone() {}
 
 int ST7735::setSleep(bool sleepMode)
 {
@@ -359,16 +352,14 @@ int ST7735::sendIndexedImage(const uint8_t *src, unsigned width, unsigned height
         else
             for (int i = 0; i < 256; ++i)
                 work->expPalette[i] = 0x1011 * (i & 0xf) | (0x110100 * (i >> 4));
-        // EventModel::defaultEventBus->listen(DEVICE_ID_DISPLAY, 100, this, &ST7735::sendDone);
     }
 
-    displayIsFree.wait();
-    if (work->inProgress || inSleepMode)
+    inProgressLock.wait();
+    if (inSleepMode)
         return DEVICE_BUSY;
 
     work->paletteTable = palette;
 
-    work->inProgress = true;
     work->srcPtr = src;
     work->width = width;
     work->height = height;


### PR DESCRIPTION
Driver fix for a bug that causes the screen to stop updating when there is high CPU demand, though the rest of the program continues as normal. This is particularly bad for sections of microbit-apps.

- The fix is an introduction of a FiberLock and removal of Event based loop.
- waitForSendDone is now deprecated.